### PR TITLE
recatml-3 Imports from TheLearningCat

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,544 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        too-many-arguments,
+        useless-import-alias
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=numpy.*,torch.*,pandas.*
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=any
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _,
+           X,
+           Y,
+           op
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=any
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/catlearn/algebra_models.py
+++ b/catlearn/algebra_models.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sun May  6 16:55:23 2018
+@author: christophe_c
+Factories to define the units and compositions of different R-algebras. These
+operators should accept batched inputs, and only work on the last dimension
+by default
+"""
+from functools import reduce
+from operator import mul
+import torch
+
+from catlearn.tensor_utils import repeat_tensor, zeros_like, DEFAULT_EPSILON
+
+
+class Algebra:
+    """
+        This is a template with the minimum an algebra should implement.
+    """
+    @property
+    def flatdim(self) -> int:
+        """
+        dimension of a representing vector
+        """
+
+        raise NotImplementedError("You need to define flatdim method when"
+                                  "defining a new algebra model")
+
+    @property
+    def dim(self) -> int:
+        """
+        semantic dimension
+        """
+
+        raise NotImplementedError("You need to define dim method when"
+                                  "defining a new algebra model")
+
+    def unit(self, data_tuple: torch.Tensor) -> torch.Tensor:
+        """
+        generator of units in batch; deduce size of batch as
+        data_tuple.shape[:-1]
+        """
+        assert data_tuple.ndimension() >= 1
+
+        raise NotImplementedError("You need to define unit method when"
+                                  "defining a new algebra model")
+
+    def comp(self, data1: torch.Tensor, data2: torch.Tensor) -> torch.Tensor:
+        """
+        composition of two algebra elements. return a third such element
+        """
+        assert data1.shape == data2.shape
+        assert data1.ndimension() >= 1
+        assert data1.shape[-1] == self.flatdim
+
+        raise NotImplementedError("You need to define comp method when"
+                                  "defining a new algebra model")
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.dim})"
+
+    def equals(
+            self,
+            left: torch.Tensor,
+            right: torch.Tensor,
+            epsilon: float = DEFAULT_EPSILON) -> bool:
+        """
+        Default equality operator (expects float-castable tensors)
+        """
+        return ((left - right) < epsilon).all()
+
+
+class VectAlgebra(Algebra):
+    """
+        A class to encapsulate a finite dimensional (possibly dependant on
+        a vector input)
+        R-vector space algebra:
+            unit is 0-vector
+            composition is vector sum
+    """
+
+    def __init__(self, dim: int) -> None:
+        """
+        Creates new instance of finite dimensional vector space algebra of a
+        given dimension
+        """
+        assert dim >= 1, "Dimension should be strictly positive"
+
+        self._dim: int = dim
+
+    @property
+    def dim(self) -> int:
+        """
+        returns the actual dimension of an element of the model
+        """
+        return self._dim
+
+    @property
+    def flatdim(self) -> int:
+        """
+        returns the actual dimension of an element of the model, once flattened
+        """
+        return self._dim
+
+    def unit(self, data_tuple: torch.Tensor) -> torch.Tensor:
+        """
+        vector unit. Takes a batch as inputs, returns 0 vectors
+        for each vector in the batch
+        """
+        assert data_tuple.ndimension() >= 1, "input should have ndim >= 1"
+
+        return zeros_like(data_tuple, data_tuple.shape[:-1] + (self.dim,))
+
+    def comp(self, data1: torch.Tensor, data2: torch.Tensor) -> torch.Tensor:
+        """
+        vector sum. Takes two batches of same shape as inputs, returns their
+        sum
+        """
+        assert data1.shape == data2.shape, "inputs should have the same shape"
+        assert data1.ndimension() >= 1, "input should have ndim >= 1"
+        assert data1.shape[-1] == self.dim, "inputs should match dim of model"
+
+        return data1 + data2
+
+
+class MatrixAlgebra(Algebra):
+    """
+    A class to encapsulate unit and composition of square matrix algebra in a
+    given dimension.
+    Constructor inputs:
+        dim: int; the dimension of the square matrices
+    """
+
+    def __init__(self, dim: int) -> None:
+        """
+        new instance of matrix algebra, from wanted dimension
+        """
+        assert dim >= 0, "Dimension should be strictly positive"
+
+        self._dim: int = dim
+
+    @property
+    def dim(self) -> int:
+        """
+        returns the actual dimension of an element of the model
+        """
+        return self._dim
+
+    @property
+    def flatdim(self) -> int:
+        """
+        returns the actual dimension of an element of the model, once flattened
+        """
+        return self._dim * self._dim
+
+    def viewmat(self, vect: torch.Tensor) -> torch.Tensor:
+        """
+        returns a view of a batch of flattened matrix as an actual batch of
+        matrices of the right shape
+        input: torch.Tensor of shape batch_shape + (dim * dim)
+        output: torch.Tensor of shape batch_shape + (dim, dim)
+        """
+        assert vect.ndimension() >= 1, "input should have ndim >= 1"
+        assert vect.shape[-1] == self.flatdim, "input should match dim of model"
+        batch_shape = vect.shape[:-1]
+
+        return vect.view(batch_shape + (self.dim, self.dim))
+
+    def unit(self, data_tuple: torch.Tensor) -> torch.Tensor:
+        """
+        matrix unit. Takes a batch of points as input, returns a batch
+        of unit matrices (reshaped in vectors) of the same shape
+        inputs:
+            data_tuple: a batch of vectors of size: batch_shape + (last_dim,)
+        outputs:
+            a batch of matrices with size batch_shape + (dim * dim,)
+        """
+        assert data_tuple.ndimension() >= 1, "input should have ndim >= 1"
+        batch_shape = data_tuple.shape[:-1]
+        n_points = reduce(mul, batch_shape, 1)
+
+        # create a tensor n_points unit matrices
+        flat_id = repeat_tensor(torch.eye(self.dim,
+                                          dtype=data_tuple.dtype,
+                                          device=data_tuple.device),
+                                n_points,
+                                axis=0)
+
+        # reshape and return
+        return flat_id.view(batch_shape + (self.flatdim,))
+
+    def comp(self, data1: torch.Tensor, data2: torch.Tensor) -> torch.Tensor:
+        """
+        definition of matrix composition, depending on dimension. Takes two
+        batches of flattened square matrices of same shape,
+        returns their batch product (flattened again)
+        inputs size: batch_shape + (dim * dim,)
+        output size: batch_shape + (dim * dim,)
+        """
+        assert data1.shape == data2.shape, "inputs should have the same shape"
+        assert data1.ndimension() >= 1, "inputs should have ndim >= 1"
+        assert data1.shape[-1] == self.flatdim, "inputs should match dim of model"
+
+        # shape of the batch
+        batch_shape = data1.shape[:-1]
+
+        # view as flat batches of square matrices
+        matrix1 = data1.view([-1, self.dim, self.dim])
+        matrix2 = data2.view([-1, self.dim, self.dim])
+
+        # batch product
+        prod_matrix = torch.bmm(matrix1, matrix2)
+
+        # reshape for return
+        return prod_matrix.view(batch_shape + (self.flatdim,))
+
+
+class AffineAlgebra(Algebra):
+    """
+    A class to encapsulate unit and composition of the real affine monoid of a
+    given dimension (semi-direct product of square matrices of given dim acting
+    on vectors of the same dim).
+    The layout is matrix first (size: dim * dim), then vector (size: dim)
+    Constructor inputs:
+        dim: int; the dimension of the square matrices and the vectors
+    """
+
+    def __init__(self, dim: int) -> None:
+        """
+        creates a new instance of real affine monoid model,
+        of a given dimension
+        """
+        assert dim >= 1, "Dimension should be strictly positive"
+
+        self._dim: int = dim
+
+    @property
+    def dim(self) -> int:
+        """
+        returns the actual dimension of an element of the model
+        """
+        return self._dim
+
+    @property
+    def flatdim(self) -> int:
+        """
+        returns the actual dimension required to store one element of the model
+        in its is flattened state: (1 + dim) * dim
+        """
+        return (1 + self._dim) * self._dim
+
+    def viewmat(self, aff: torch.Tensor) -> torch.Tensor:
+        """
+        taking a batch of flattened (mat, vector) couples as inputs, returns
+        a view of the corresponding batch of matrices
+        """
+        assert aff.ndimension() >= 1, "input should have ndim >= 1"
+        assert aff.shape[-1] == self.flatdim, "input should match dim of model"
+
+        # get batch schape
+        batch_shape = aff.shape[:-1]
+
+        # flatt view of matrices
+        flat_mat = aff[..., :(self.dim * self.dim)]
+
+        return flat_mat.view(batch_shape + (self.dim, self.dim))
+
+    def viewvect(self, aff: torch.Tensor) -> torch.Tensor:
+        """
+        taking a batch of flattened (mat, vector) couples as inputs, returns
+        a view of the corresponding batch of vectors as column vectors (last
+        dim is 1)
+        """
+        assert aff.ndimension() >= 1, "input should have ndim >= 1"
+        assert aff.shape[-1] == self.flatdim, "input should match dim of model"
+
+        return aff[..., (self.dim * self.dim):, None]
+
+    def unit(self, data_tuple: torch.Tensor) -> torch.Tensor:
+        """
+        affine unit (id matrix, 0 vector). Takes a batch of points as input,
+        returns a batch of unit matrices (reshaped in vectors)
+        of the same shape
+        inputs:
+            data_tuple: a batch of vectors of any size
+        outputs:
+            a batch of matrix-vector couples with the same size
+            (except last dim), flattened
+        """
+        assert data_tuple.ndimension() >= 1, "Input should have ndim >= 1"
+
+        # shape and size of batch
+        batch_shape = data_tuple.shape[:-1]
+        n_points = reduce(mul, batch_shape, 1)
+
+        # create a single unit, then repeat it
+        single_unit = torch.cat((torch.eye(self.dim,
+                                           dtype=data_tuple.dtype,
+                                           device=data_tuple.device).view([-1]),
+                                 zeros_like(data_tuple, (self.dim,))))
+        flat_unit = repeat_tensor(single_unit, n_points, axis=0)
+
+        # reshape for return
+        return flat_unit.view(batch_shape + (self.flatdim,))
+
+    def comp(self, data1: torch.Tensor, data2: torch.Tensor) -> torch.Tensor:
+        """
+        returns composition of two affine elements, that is matrix-vector
+        couples (M1, v1), (M2, v2), given by: (M1@M2, M1@v2 + v1)
+        """
+        assert data1.shape == data2.shape, "inputs should have the same shape"
+        assert data1.ndimension() >= 1, "inputs should have ndim >= 1"
+        assert data1.shape[-1] == self.flatdim, "inputs should match model dim"
+
+        # get batch shape and size
+        n_points = reduce(mul, data1.shape, 1) // self.flatdim
+
+        # flatten batches
+        flat1 = data1.view([n_points, self.flatdim])
+        flat2 = data2.view([n_points, self.flatdim])
+
+        # get a view of all corresponding batches of matrices and vectors
+        mat1 = self.viewmat(flat1)
+        vect1 = self.viewvect(flat1)
+
+        mat2 = self.viewmat(flat2)
+        vect2 = self.viewvect(flat2)
+
+        # compute result matrix and vector parts
+        result_mat = torch.bmm(mat1, mat2)
+        result_vect = torch.bmm(mat1, vect2) + vect1
+
+        # flatten and concatenate both parts to get the output
+        result = torch.cat(
+            (result_mat.view([n_points, self.dim * self.dim]),
+             result_vect.view([n_points, self.dim])),
+            -1
+        )
+
+        # reshape and return
+        return result.view(data1.shape)

--- a/catlearn/device_utils.py
+++ b/catlearn/device_utils.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Various utilities for device placement
+"""
+
+from torch import nn
+
+
+def to_device(device: str, model: nn.Module) -> None:
+    """ Send model to specified device
+
+    Accepts 'cpu' or 'cuda' for generic placement,
+    or specific device placement eg 'cuda:1' to move
+    to 2nd available GPU.
+    """
+    for p in model.parameters():
+        if device == 'cpu':
+            p.cpu()
+        elif device == 'cuda':
+            p.cuda()
+        else:
+            p.device(device)

--- a/catlearn/full_layer_models.py
+++ b/catlearn/full_layer_models.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+This file introduces factories to define full perceptron models
+"""
+from functools import reduce
+from itertools import chain
+from operator import mul
+from typing import Any, Callable, Sequence, Tuple, Iterable
+import torch
+import torch.nn as nn
+
+
+class ConstantModel(nn.Module):
+    """ Encapsulate a non-parametrized transform """
+
+    def __init__(self, func: Callable, name: str = 'ConstantModel') -> None:
+        nn.Module.__init__(self)
+        self._forward = func
+        self.name = name
+
+    def __repr__(self) -> str:
+        """
+        Readable representation
+
+        We must do so because func might not be readable,
+        and if it part of nn modules or sub package, can get tricky.
+        """
+        return self.name
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        """ Forward override """
+        assert len(inputs) == 1
+        return self._forward(inputs[0])
+
+
+class LayeredModel(nn.Module):
+    """
+    A generic class to represent layered models.
+    Takes batch of tensors as inputs and outputs
+    """
+    def __init__(
+            self,
+            input_shape: Sequence[int],
+            output_shape: Sequence[int],
+            layers: Iterable[Callable]) -> None:
+
+        # parent init
+        nn.Module.__init__(self)
+
+        # register inputs as parameters
+        self._input_shape = torch.Size(input_shape)
+        self._output_shape = torch.Size(output_shape)
+
+        # Uses Sequential here for easy human readable
+        # representation, reuse of forward definition.
+        self.layers = nn.Sequential(*list(layers))
+
+    @property
+    def input_shape(self) -> torch.Size:
+        """ Get shape of expected input tensor
+
+        """
+        return self._input_shape
+
+    @property
+    def input_ndim(self) -> int:
+        """ Get number of dimensions of expected input tensor
+
+        """
+        return len(self.input_shape)
+
+    @property
+    def input_numel(self) -> int:
+        """ Get number of elements of expected input tensor
+
+        """
+        return reduce(mul, self.input_shape, 1)
+
+    @property
+    def output_shape(self) -> torch.Size:
+        """ Get expected output tnsor shape
+
+        """
+        return self._output_shape
+
+    @property
+    def output_ndim(self) -> int:
+        """
+        Get expected number of dimensions of output tensor
+        """
+        return len(self.output_shape)
+
+    @property
+    def output_numel(self) -> int:
+        """ Get expected number of elements of output tensor
+
+        """
+        return reduce(mul, self.output_shape, 1)
+
+    @property
+    def children(self) -> Callable[[], Iterable[nn.Module]]:
+        """ Gather children models of parent
+
+        """
+        return lambda: self.layers.children()
+
+    @property
+    def parameters(self) -> Callable[[], Iterable[Any]]:
+        """ Function to gather all parameters of the model: go through layer and
+        check if each layer has an attribute "parameters"
+        """
+        return lambda: self.layers.parameters()
+
+    def forward(self, *inputs: torch.Tensor) -> torch.Tensor:
+        """ Forward pass of Layered Model """
+        assert len(inputs) == 1
+        input_batch = inputs[0]
+        assert input_batch.ndimension() >= self.input_ndim
+        assert input_batch.shape[-self.input_ndim:] == self.input_shape
+        return self.layers.forward(input_batch)
+
+    def _set_requires_grad_flag(self, value: bool) -> None:
+        """ Set requires_grad flag on all parameters of the model
+
+        """
+        for layer in self.parameters():
+            layer.requires_grad_(value)
+
+    def freeze(self) -> None:
+        """ Freeze parameters of the model
+
+        After this call, parameters will not be
+        affected by torch.backward pass.
+        Parameters are NOT frozen by default.
+        """
+        return self._set_requires_grad_flag(False)
+
+    def unfreeze(self) -> None:
+        """ Inverse of model freeze
+
+        After this call, parameters can
+        be optimized again.
+        """
+        return self._set_requires_grad_flag(True)
+
+
+def couple_layered_models(
+        *models: LayeredModel) -> LayeredModel:
+    """
+    Concatenates a sequence of Layered models into a single,
+    unified one, resulting in a LayeredModel with all the layers.
+
+    Model order is respected, and they must all be compatible,
+    ie outshape shape of previous module is equal to input shape
+    of the next one.
+    """
+    assert len(models) >= 2
+    assert all(m1.output_shape == m2.input_shape
+               for m1, m2 in zip(models, models[1:]))
+
+    # list of layers is concatenation of lists of layers of the two models
+    layers = chain(* map(lambda m: m.layers, models))
+
+    # input shape inherited from first model, output shape from second model
+    input_shape = models[0].input_shape
+    output_shape = models[-1].output_shape
+
+    return LayeredModel(input_shape, output_shape, layers)
+
+
+def reduce_model(model: LayeredModel) -> LayeredModel:
+    """
+    Takes a layered model as input and compose all its layers to a single one
+    """
+    return LayeredModel(model.input_shape, model.output_shape, [model])
+
+
+class FullPerceptron(LayeredModel):
+    """
+    Creates a full perceptron model with Tensor shaped input and output
+    Constructor takes as arguments:
+        input_shape: shape of 1 input (Tuple)
+        output_shape: shape of 1 output (Tuple)
+        num_units: lists of numbers of units of intermediary layers
+        activation_factory: create new activation function,
+        separate for each layer
+    """
+    def __init__(
+            self,
+            input_shape: Sequence[int],
+            output_shape: Sequence[int],
+            num_units: Sequence[int],
+            activation_factory: Callable[[], nn.Module]) -> None:
+        """
+        Create a new multilayer perceptron, taking arbitrary size inputs
+        and returning arbitrary size outputs
+        """
+
+        # register input and output shapes as attributes
+        self._input_shape = torch.Size(input_shape)
+        self._output_shape = torch.Size(output_shape)
+
+        # get list of units for a flat perceptron model and create this model
+        internal_modules = self._get_layer_sequence(
+            num_units, activation_factory)
+        modules = chain(
+            [ConstantModel(
+                self._view_input,
+                f"Flatten {tuple(self._input_shape)}")],
+            internal_modules,
+            [ConstantModel(
+                self._view_output,
+                f"Reshape {tuple(self._output_shape)}")])
+        LayeredModel.__init__(self, input_shape, output_shape, modules)
+
+    def _get_layer_sequence(
+            self,
+            num_units: Sequence[int],
+            activation_factory: Callable[[], nn.Module]
+    ) -> Iterable[nn.Module]:
+        """ Generate the sequence of modules to use """
+        # total number of inputs and outputs
+        input_numel = reduce(mul, self._input_shape, 1)
+        output_numel = reduce(mul, self._output_shape, 1)
+        all_units = [input_numel] + list(num_units) + [output_numel]
+        internals = (
+            (nn.Linear(in_shape, out_shape, bias=True),
+             activation_factory())
+            for in_shape, out_shape in zip(all_units, all_units[1:-1]))
+        last_layer = nn.Linear(all_units[-2], all_units[-1], bias=True)
+        return chain(*internals, [last_layer])
+
+    def _view_input(self, batch_input: torch.Tensor) -> torch.Tensor:
+        """
+        A function to reshape batch for input in the underlying
+        perceptron model, by flattening the input shape
+        inputs:
+            batch_input: torch.Tensor, last dims are self.input_shape
+        outputs:
+            torch.Tensor, view of input with last self.input_ndim
+            flattened to a singledimension
+        """
+        assert batch_input.ndimension() >= self.input_ndim
+        assert batch_input.shape[-self.input_ndim:] == self.input_shape
+
+        batch_shape = batch_input.shape[:-self.input_ndim]
+        return batch_input.view(batch_shape + (-1,))
+
+    def _view_output(self, batch_output: torch.Tensor) -> torch.Tensor:
+        """
+        A function to reshape batch out of the underlying perceptron model
+        for output, respecting the instance's output_shape
+        inputs:
+            batch_input: torch.Tensor, last dim is self.output_numel
+        outputs:
+            torch.Tensor, last dim is recast as self.output_shape
+        """
+        assert batch_output.ndimension() >= 1
+        assert batch_output.shape[-1] == self.output_numel
+
+        batch_shape = batch_output.shape[:-1]
+        return batch_output.view(batch_shape + self.output_shape)
+
+
+class FullPerceptronWithRandomState(LayeredModel):
+    """
+    create a full layer perceptron which augments its input with a random state
+    Constructor takes as input:
+        input_shape: shape of 1 input (Tuple)
+        output_shape: shape of output (Tuple)
+        num_units: lists of numbers of units of intermediary layers
+        activation_factory: create new activation function,
+                            separate for each layer
+        num_random: the number of random states
+        random generator: random generator to use; default as torch.rand
+    """
+    def __init__(self,
+                 input_shape: Sequence[int],
+                 output_shape: Sequence[int],
+                 num_units: Sequence[int],
+                 num_random: int,
+                 activation_factory: Callable[[], nn.Module],
+                 random_generator: Callable = torch.rand) -> None:
+        """
+        Creates a new instance of perceptron model with random state
+        """
+        assert num_random >= 1, "if no randomization, use FullPerceptron class"
+
+        # register parameters for random draws
+        self.num_random = num_random
+        self.random = random_generator
+
+        # register input and output shapes as attributes
+        self._input_shape = torch.Size(input_shape)
+        self._output_shape = torch.Size(output_shape)
+
+        # get number of inputs, including random state
+        num_inputs = num_random + reduce(mul, input_shape, 1)
+
+        # create a perceptron model without random state
+        deterministic_model = FullPerceptron(
+            (num_inputs,), output_shape, num_units, activation_factory)
+
+        # add input augmentation at beginning of ops list and call parent init
+        op_list = chain([ConstantModel(self.augment_input, f"RandomAugment")],
+                        deterministic_model.children())
+        LayeredModel.__init__(self, input_shape, output_shape, op_list)
+
+    def draw_state(self, batch_shape: Tuple[int, ...]) -> torch.Tensor:
+        """
+        draw a batch of state vectors for input in the underlying perceptron
+        model
+        inputs:
+            batch_shape:  Tuple of integers, shape of input
+        """
+        return self.random(batch_shape + (self.num_random,))
+
+    def augment_input(self, batch_input: torch.Tensor) -> torch.Tensor:
+        """
+        flatten inputs in the batch and concatenate it with a randomly drawn
+        state
+        """
+        assert batch_input.shape[-self.input_ndim:] == self.input_shape
+
+        batch_shape = batch_input.shape[:-self.input_ndim]
+        flat_input = batch_input.view(batch_shape + (-1,))
+        random_state = self.draw_state(batch_shape)
+
+        return torch.cat((flat_input, random_state), -1)

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -1,0 +1,493 @@
+"""
+Created on Wed Mar 13 13:47:33 2019
+
+@author: christophe_c
+A library for graph utilities used in our project.
+"""
+from __future__ import annotations
+from typing import (
+    Iterable, FrozenSet, Sequence, TypeVar, Generic,
+    Optional, Callable, Tuple, Iterator, Type, Any, Mapping)
+from itertools import chain, product
+from collections import abc
+import random
+import pickle
+
+import numpy as np
+from networkx import DiGraph, NetworkXError
+
+NodeType = TypeVar("NodeType")
+ArrowType = TypeVar("ArrowType")
+AlgebraType = TypeVar("AlgebraType")
+
+
+def mapping_product(mapping0: Mapping, mapping1: Mapping) -> Iterator:
+    """
+    from two mapping {k0: d0, ...}, {k1: d1, ...}, returns an iterator
+    emulating items of a dictionary {(k0, k1): (d0, d1)}
+    """
+    return (
+        tuple(zip(pair0, pair1))
+        for (pair0, pair1) in product(mapping0.items(), mapping1.items()))
+
+
+class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: disable=unsubscriptable-object
+    """
+    A class to encapsulate directed graphs. Initialized from a dictionary:
+    Values are iterable which must range over keys of the dictionary.
+    For a key k,  v in self[k] means there is a vertex k -> v.
+    Different graph composition functions are provided in order to facilitate
+    the generation of examples.
+    """
+    def __delitem__(self, node: NodeType) -> None:
+        """
+        delete a node from the graph
+        """
+        try:
+            self.remove_node(node)
+        except NetworkXError:
+            raise KeyError(f"{node} could not be found in graph")
+
+    def __setitem__(
+            self, node: NodeType, children: Iterable[NodeType]) -> None:
+        """
+        add given edge to the graph
+        """
+        # wether input is a mapping
+        is_mapping = isinstance(children, Mapping)
+
+        self.add_node(node)
+        for child in children:
+            self.add_edge(node, child)
+            if is_mapping:
+                labels = children[child]  # type: ignore
+                if isinstance(labels, Mapping):
+                    self[node][child].update(labels)
+
+    @property
+    def op(self) -> DirectedGraph[NodeType]:
+        """
+        returns the opposite graph
+        """
+        return self.reverse(copy=False)
+
+    def under(self, root: NodeType) -> FrozenSet[NodeType]:
+        """
+        Returns the set of all nodes acessible from given root,
+        (not included root itself unless there is a cycle going back to it)
+        """
+        # get the set of first order children
+        first_children = self[root]
+
+        # use _under function to get subsequent children
+        return self._under(frozenset(first_children))
+
+    def _under(self, roots: FrozenSet[NodeType]) -> FrozenSet[NodeType]:
+        """
+        Returns the sef of all nodes accessible from given roots
+        (including roots themselves)
+        """
+        # get the set of first order children which are not roots
+        first_children = frozenset(chain(*(self[root] for root in roots)))
+
+        # if first children are among roots, return roots
+        if first_children <= roots:
+            return roots
+
+        # otherwise make recursive call on roots
+        return self._under(roots | first_children)
+
+    def over(self, root: NodeType) -> FrozenSet[NodeType]:
+        """
+        Returns the set of all nodes from which given root can be accessed,
+        (not included root itself unless there is a cycle going back to it)
+        """
+        return self.op.under(root)
+
+    def subgraph(self, nodes: Iterable[NodeType]) -> DirectedGraph[NodeType]:
+        """
+        Extract a subgraph of current graph constituted of given nodes
+        """
+        nodes_set = frozenset(nodes)
+        return type(self)(
+            {node: set(self[node]) & nodes_set for node in nodes_set})
+
+    def prune(self, node: NodeType) -> DirectedGraph[NodeType]:
+        """
+        Prune a node out of the graph, but making sure that for any subgraph
+        i -> pruned_node -> j, there is a i -> j vertex added
+        """
+        # get parents and children of node
+        parents = self.op[node].copy()
+        children = self[node].copy()
+
+        # delete node
+        del self[node]
+
+        # add children to all parents' children sets
+        for (parent, child) in product(parents, children):
+            self.add_edge(parent, child)
+            self[parent][child].update(mapping_product(
+                parents[parent], children[child]))
+
+        return self
+
+    def __repr__(self) -> str:
+        """
+        return string representation of object
+        """
+        return (
+            f"{type(self).__name__}("
+            + ", ".join(
+                f"{node} > {children}"
+                for node, children in self.items())
+            + ")")
+
+    def __or__(
+            self, other_graph: DirectedGraph[NodeType]
+    ) -> DirectedGraph[Tuple[bool, NodeType]]:
+        """
+        Generates a new directed graph by making the disjoint sum
+        of both graphs. Changes the nodes to:
+            (False, node) for nodes from the first graph
+            (True, node) for nodes from the second
+        """
+        remap_self = {
+            (False, key): {
+                (False, value):  labels for value, labels in values.items()}
+            for key, values in self.items()}
+        remap_other = {
+            (True, key): {
+                (True, value): labels for value, labels in values.items()}
+            for key, values in other_graph.items()}
+        return type(self)({**remap_self, **remap_other})
+
+    def __and__(
+            self, other_graph: DirectedGraph[NodeType]
+    ) -> DirectedGraph[Tuple[NodeType, NodeType]]:
+        """
+        Generates a new directed graph by making the cartesian product
+        of both graphs, in the category theoretic sense of the term.
+        """
+        return type(self)({
+            (key0, key1): {
+                product_node: mapping_product(*labels)
+                for product_node, labels in mapping_product(value0, value1)}
+            for (key0, value0), (key1, value1)
+            in product(self.items(), other_graph.items())})
+
+    def __add__(
+            self, other_graph: DirectedGraph[NodeType]
+    ) -> DirectedGraph[Tuple[bool, NodeType]]:
+        """
+        Generates a new directed graph by making the directed join of both
+        graphs:
+            nodes are:
+                (False, node) for nodes in the first graph
+                (True, node) for nodes in the second graph
+            edges are:
+                (x, n0) -> (x, n1) for n0, n1 nodes in the same base graph
+                (False, n0) -> (True, n1) for any nodes n0 and n1 in the
+                    first and second graph respectively?
+        """
+        remap_self = {
+            (False, key): {
+                **{(False, value): labels for value, labels in values.items()},
+                **{(True, other_key): {} for other_key in other_graph}}
+            for key, values in self.items()}
+        remap_other = {
+            (True, key): {
+                (True, value): labels for value, labels in values.items()}
+            for key, values in other_graph.items()}
+        return type(self)({**remap_self, **remap_other})
+
+    def __matmul__(
+            self,
+            other_graph: DirectedGraph[NodeType]
+    ) -> DirectedGraph[Tuple[NodeType, NodeType]]:
+        """
+        Generates a new directed graph by making the product of the graph in
+        that:
+            - nodes are pairs (node0, node1) of nodes of each graph
+            - (s0, s1) and (t0, t1) are linked by an edge if there is an edge
+            (s0, t0), or (s1, t1)
+        """
+        return type(self)({
+            (key0, key1): {
+                **{
+                    (value0, key1): {
+                        (False, label_name): label_value
+                        for (label_name, label_value) in labels0.items()}
+                    for (value0, labels0) in self[key0].items()},
+                **{
+                    (key0, value1): {
+                        (True, label_name): label_value
+                        for (label_name, label_value) in labels1.items()}
+                    for (value1, labels1) in other_graph[key1].items()}
+                }
+            for key0, key1 in product(self, other_graph)})
+
+    def __mul__(
+            self, other_graph: DirectedGraph[NodeType]
+    ) -> DirectedGraph[Tuple[NodeType, NodeType]]:
+        """
+        Generates a new directed graph by making the directed product of both
+        graphs (lexicographic order)
+        """
+        return type(self)({
+            (key0, key1): {
+                **{
+                    (value0, key1): labels0
+                    for value0, labels0 in values0.items()},
+                **{
+                    (key, value1): labels1
+                    for (key, (value1, labels1))
+                    in product(self, values1.items())}}
+            for (key0, values0), (key1, values1)
+            in product(self.items(), other_graph.items())})
+
+    def remap_names(
+            self, key_func: Callable[[Any], Any]
+    ) -> DirectedGraph[Any]:
+        """
+        Remap the graph nodes to new names using a function key_func to
+        generate the new names.
+        Be careful that the function is 1-to-1 if you want to make sure you
+        do not lose certain properties of the graph, such as being acyclic
+        """
+        return type(self)({
+            key_func(key): {
+                key_func(value): labels
+                for value, labels in values.items()}
+            for key, values in self.items()})
+
+    def integerify(self) -> DirectedGraph[int]:
+        """
+        Remap the graph nodes to integers, starting from 0 in the order of
+        access in the underlying dictionary
+        """
+        # create a dictionary which will be used to create the mapping
+        sorted_nodes = enumerate(sorted(self, key=pickle.dumps))
+        remapping = {node: index for index, node in sorted_nodes}
+        return self.remap_names(remapping.get)
+
+    def stringify(self) -> DirectedGraph[str]:
+        """
+        Remap the graph nodes to strings generated from the
+        hash code of each key
+        """
+        return self.integerify().remap_names(hex)
+
+    def rand_prune(
+            self, pruning_factor: float,
+            random_generator: Optional[random.Random] = None
+    ) -> DirectedGraph[NodeType]:
+        """
+        Randomly prune nodes out of the graph. The number of nodes pruned out
+        of the graph is floor(pruning_factor * len(self)),
+        chosen without replacement
+        """
+        assert 0 <= pruning_factor <= 1, (
+            "pruning_factor should be a number between 0. and 1.")
+        nb_to_prune = int(np.floor(pruning_factor * len(self)))
+
+        # draw nodes to be pruned
+        if random_generator is None:
+            to_prune = random.sample(
+                list(self), k=nb_to_prune)  # type: ignore
+        else:
+            to_prune = random_generator.sample(
+                list(self), k=nb_to_prune)  # type: ignore
+
+        # prune nodes
+        for node in to_prune:
+            self.prune(node)
+
+        return self
+
+
+class DirectedAcyclicGraph(DirectedGraph[NodeType]):
+    """
+        A class to model general directed acyclic graphs
+    """
+    def __init__(self, *args, **kwargs) -> None:
+        """
+            Create an acyclic directed graph from a dictinary.
+        """
+
+        # init self as directed graph
+        super().__init__(*args, **kwargs)
+
+        # check that it is indeed a directed acyclic graph
+        assert all(node not in self.under(node) for node in self), (
+            "A directed acyclic graph cannot contain cycles")
+
+    @property
+    def ins(self) -> FrozenSet[NodeType]:
+        """
+        roots of the graph
+        """
+        return frozenset(node for node in self if not self.op[node])
+
+    @property
+    def outs(self) -> FrozenSet[NodeType]:
+        """
+        roots of the opposite graph
+        """
+        return frozenset(node for node in self if not self[node])
+
+    def __setitem__(self, node: NodeType, children: Iterable[NodeType]):
+        """
+        item setting is forbidden in a DirectedAcyclicGraph. Go through
+        a DirectedGraph representation if you need to do this, then recreate
+        a DirectedAcyclicGraph out of it
+        """
+        raise NotImplementedError(
+            "item setting is not supported by DirectedAcyclicGraph objects")
+
+
+class GraphRandomFactory:
+    """
+    A class for factories for random graph generation.
+    Arguments to the constructor are:
+        weights: a sequence of 5 floating point numbers, whose sum
+            is less than 1, for the weights of choosing respectively the
+            or, and, add, mul, matmul
+        nb_graphs: the number of graphs kept into memory by the generator
+        pruning_factor: the max pruning factor for the eroding operation.
+            The eroding operation is chosen whenever no other operation is
+            chosen, and randomly prunes a number of points of one of the graphs
+        random_generator: random.Random, the random generator to use
+        *initial_graphs: DirectedGraph objects, seeds to initialize the random
+            generation (at most nb_graphs). If not provided, a default seed
+            point graph will be used.
+    """
+    OPS: Tuple[Callable[..., DirectedGraph], ...] = (
+        DirectedGraph.__or__,
+        DirectedGraph.__and__,
+        DirectedGraph.__add__,
+        DirectedGraph.__mul__,
+        DirectedGraph.__matmul__)
+    OPS_NARGS = (2, 2, 2, 2, 2)
+
+    DEFAULT_SEED_GRAPH = DirectedGraph[str]({"0x0": []}).stringify()
+
+    @classmethod
+    def __init_subclass__(cls: Type) -> None:
+        """
+        Verify that the defined OPS and OPS_NARGS are tuples of same length
+        """
+        assert isinstance(cls.OPS, tuple), "OPS should be a tuple"
+        assert isinstance(cls.OPS_NARGS, tuple), "OPS_NARGS should be a tuple"
+        assert len(cls.OPS) == len(cls.OPS_NARGS), (
+            "OPS and OPS_NARGS should have the same length")
+
+    def __init__(
+            self, weights: Sequence[float], nb_graphs: int,
+            pruning_factor: float,
+            random_generator: random.Random,
+            *initial_graphs: DirectedGraph[Any]) -> None:
+        """
+        create a new factory
+        """
+        assert 0. <= pruning_factor <= 1., (
+            "pruning factor should be between 0. and 1.")
+        assert len(weights) == len(__class__.OPS), (  # type: ignore
+            "Weights sequence should be of length 5, for"
+            " or, and, add, mul, matmul operations respectively")
+        assert 0 <= len(initial_graphs) <= nb_graphs, (
+            "number of initializer "
+            "graphs should be at most nb_graphs: {nb_graphs}")
+        assert all(weight >= 0. for weight in weights), (
+            "weights should be positive")
+        assert sum(weights) <= 1, "Weights should sum to less to 1."
+
+        self._pruning_factor = pruning_factor
+        self._weights = np.array(tuple(weights) + (1. - sum(weights),))
+        self._nb_graphs = nb_graphs
+        self._random_generator = random_generator
+        self._ops = type(self).OPS + (self.erode,)
+        self._ops_nargs = type(self).OPS_NARGS + (1,)
+
+        self._graphs: Tuple[DirectedGraph, ...]
+        if initial_graphs:
+            self._graphs = tuple(graph.stringify() for graph in initial_graphs)
+        else:
+            self._graphs = (type(self).DEFAULT_SEED_GRAPH,)
+
+    def erode(self, graph: DirectedGraph) -> DirectedGraph:
+        """
+        Erode the given graph by pruning it of a factor of at most the
+        pruning_factor of the factory.
+        """
+        # get a random pruning factor between 0. and actual pruning_factor
+        pruning_factor = self._random_generator.uniform(
+            0., self._pruning_factor)
+        return graph.rand_prune(pruning_factor)
+
+    @property
+    def nb_graphs(self) -> int:
+        """
+        Number of graphs held in memory by the factory
+        """
+        return self._nb_graphs
+
+    @property
+    def graphs(self) -> Tuple[DirectedGraph, ...]:
+        """
+        tuple containing the graphs held in the memory of the factory
+        """
+        return self._graphs
+
+    @property
+    def weights(self) -> np.ndarray:
+        """
+        weights of or, and, add, mul operations for the factory
+        """
+        return self._weights
+
+    @property
+    def ops(self) -> Tuple[Callable[..., DirectedGraph], ...]:
+        """
+        return list of operations of the factory
+        """
+        return self._ops
+
+    @property
+    def ops_nargs(self) -> Tuple[int, ...]:
+        """
+        number of arguments of each operand
+        """
+        return self._ops_nargs
+
+    def __next__(self) -> Tuple[DirectedGraph, ...]:
+        """
+        generate next step graphs from current ones
+        """
+        # draw operations to apply for each new graph
+        ops = self._random_generator.choices(
+            list(enumerate(self.ops)), weights=self.weights,
+            k=self.nb_graphs)
+
+        # number of operands for each operation
+        ops_nargs = [self.ops_nargs[index] for index, _ in ops]
+
+        # choose wether the operands are taken as direct or opposite
+        operands_variance = (
+            self._random_generator.choices([False, True], k=op_nargs)
+            for op_nargs in ops_nargs)
+
+        # get operands for each operation, with their right variance
+        operands = (
+            map(
+                lambda graph, var: graph if var else graph.op,
+                self._random_generator.choices(self.graphs, k=op_nargs),
+                ops_vars)
+            for op_nargs, ops_vars in zip(ops_nargs, operands_variance))
+
+        # generate new graphs
+        self._graphs = tuple(
+            op(*args).stringify()
+            for (_, op), args in zip(ops, operands))
+
+        return self._graphs

--- a/catlearn/tensor_utils.py
+++ b/catlearn/tensor_utils.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Wed May 30 20:53:39 2018
+
+@author: christophe_c
+
+various utilities for tensor manipulation
+"""
+
+from typing import Optional, Sequence
+import torch
+from torch.nn.functional import kl_div
+
+# default precision of computations
+DEFAULT_EPSILON = 1e-6
+
+
+def repeat_tensor(
+        to_repeat: torch.Tensor,
+        nb_repeats: int,
+        axis: int,
+        copy: bool = False) -> torch.Tensor:
+    """
+    stacks a tensor over itself nb_repeats times, over axis dimension
+
+    /!\\ Default behavior (copy=False) does not allocate new memory.
+    Any mutation of the resulting tensor's new axis will be shared
+    across the new dimension!
+
+    inputs:
+        to_repeat: the tensor to stack
+        nb_repeats: the number of times one wants to repeat the tensor
+        axis: on which axis to repeat
+        copy: should repeat allocate new memory? Otherwise a view is returned
+    """
+    # Torch repeat expects 0 <= axis <= ndimension
+    ndim = to_repeat.ndimension()
+    if axis < 0:
+        axis += ndim + 1
+
+    existing_dim = 1 if copy else -1
+    pattern = [existing_dim for _ in range(ndim + 1)]
+    pattern[axis] = nb_repeats
+    if copy:
+        return to_repeat.unsqueeze(axis).repeat(*pattern)
+    return to_repeat.unsqueeze(axis).expand(*pattern)
+
+
+def is_shape_broadcastable(
+        first_shape: Sequence,
+        last_shape: Sequence) -> bool:
+    """
+    Test if two shapes can be broadcasted together, following numpy/pytorch
+    conventions
+    """
+    # iterate on couple of dims from last; will stop when one shape is depleted
+    # check individual dimensions from end are broadcastable
+    return all((m == n) or (m == 1) or (n == 1)
+               for m, n in zip(first_shape[::-1], last_shape[::-1]))
+
+
+def sorted_weighted_sum(
+        to_sum: torch.Tensor,
+        weights: torch.Tensor,
+        axis: int,
+        keepdim: bool,
+        largest: bool) -> torch.Tensor:
+    """
+    Orders elements to sum then sums them with given ponderations
+    inputs:
+        to_sum: a tensor, will be sumed on the given axes
+        weights: weights to apply to the summands. If smaller than number of
+                elements to sum, 0 padding is assumed
+        axis: the axis on which to perform reduction
+        keepdim: wether the reduced axis should be kept in shape
+                the tensor after ordered summation on the required axis
+        largest: wether the k largest are returned;
+                otherwise the k smallest are returned
+    outputs:
+        torch.Tensor, of shape :
+            input_shape[:(axis-1)] + input_shape[(axis+1):] if
+                keepdim is false
+            input_shape[:(axis-1)] + (1,) + input_shape[(axis+1):] if
+                keepdim is true
+    """
+    nb_weights = weights.numel()
+    assert weights.ndimension() == 1
+    assert nb_weights <= to_sum.shape[axis]
+
+    # get the top k elements on the required axis (k = number of weights)
+    sorted_topk = torch.topk(to_sum, nb_weights, sorted=True,
+                             dim=axis, largest=largest)[0]
+
+    # view of weights with the right shape for broadcasting
+    nb_dims = to_sum.ndimension()
+    reshaped_weights = weights.view([nb_weights
+                                     if (ax - axis) % nb_dims == 0 else 1
+                                     for ax in range(nb_dims)])
+
+    # weighted sum returned as result
+    return torch.sum(reshaped_weights * sorted_topk,
+                     dim=axis, keepdim=keepdim)
+
+
+def tensor_equals(
+        left: torch.Tensor,
+        right: torch.Tensor,
+        precision: float = 1e-6) -> bool:
+    """ Are two tensors equal? """
+    return torch.lt(
+        torch.abs(left.double() - right.double()), precision).all()
+
+
+def full_like(
+        value,  # numbers.Real but mypy does not like it...
+        tensor: torch.Tensor,
+        shape: Optional[Sequence[int]] = None) -> torch.Tensor:
+    """
+    Create a new `value`-filled tensor based on an input tensor.
+    NB: type, device and layout are conserved
+    """
+    if shape is None:
+        shape = tensor.size()
+    return torch.full(
+        shape, value, dtype=tensor.dtype,
+        device=tensor.device, layout=tensor.layout)
+
+
+def zeros_like(
+        tensor: torch.Tensor,
+        shape: Optional[Sequence[int]] = None) -> torch.Tensor:
+    """
+    Create a new 0-filled tensor based on an input tensor.
+    NB: type, device and layout are conserved
+    """
+    return full_like(0.0, tensor, shape)
+
+
+def ones_like(
+        tensor: torch.Tensor,
+        shape: Optional[Sequence[int]] = None) -> torch.Tensor:
+    """
+    Create a new 1-filled tensor based on an input tensor.
+    NB: type, device and layout are conserved
+    """
+    return full_like(1.0, tensor, shape)
+
+
+def clip_proba(
+        proba_vector: torch.Tensor,
+        dim: int = -1,
+        epsilon: float = DEFAULT_EPSILON) -> torch.Tensor:
+    """
+    clip a probability vector to remove pure 0. and 1. values, to avoid
+    numerical errors. Also works on subprobability vectors.
+
+    Arguments:
+        proba_vector: the tensor of probability vectors
+        dim: the dimension on which values can be interpreted as probabilities
+        epsilon: the clipping numerical tolerance
+    """
+    if proba_vector.ndimension() == 0:
+        vector_size = 1.
+    else:
+        vector_size = float(proba_vector.shape[dim])
+    return (1. - vector_size * epsilon) * proba_vector + epsilon
+
+
+def subproba_kl_div(
+        predicted: torch.Tensor, labels: torch.Tensor,
+        epsilon: float = DEFAULT_EPSILON,
+        dim: int = -1, keepdim: bool = False) -> torch.Tensor:
+    """
+    compute KL-divergence of subprobability vectors, extending them to sum to 1
+    The dim on which they are assumed to be subprobability vectors is -1
+    by default
+    """
+    # compute complement vectors
+    complement_predicted = 1. - predicted.sum(dim=dim, keepdim=keepdim)
+    complement_labels = 1. - labels.sum(dim=dim, keepdim=keepdim)
+
+    # compute raw KL-div (unsumed) of vectors and their complement
+    kl_direct = kl_div(
+        torch.log(clip_proba(predicted, dim=dim, epsilon=epsilon)),
+        labels, reduction="none")
+    kl_complement = kl_div(
+        torch.log(clip_proba(complement_predicted, dim=dim, epsilon=epsilon)),
+        complement_labels, reduction="none")
+
+    # sum all components of kl and return
+    return kl_direct.sum(dim=dim, keepdim=keepdim) + kl_complement

--- a/tests/test_algebramodels.py
+++ b/tests/test_algebramodels.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""
+tests for algebra models
+"""
+
+import inspect
+from typing import Any, Tuple
+import pytest
+import torch
+
+from catlearn import algebra_models
+from tests.test_tools import random_int_list
+
+# List of algebras to verify
+# Automagic, adding an algebra will get tested right away
+CLASSES_TO_TEST = list(
+    filter(
+        lambda x: (inspect.isclass(x) and
+                   x != algebra_models.Algebra and
+                   issubclass(x, algebra_models.Algebra)),
+        map(
+            lambda x: x[1],
+            inspect.getmembers(algebra_models)
+        )
+    )
+)
+
+
+@pytest.fixture(params=[1, 3])
+def ndim(request: Any) -> int:
+    """ Albegra dimension """
+    return request.param
+
+
+@pytest.fixture(params=CLASSES_TO_TEST)
+def algebra(request: Any, ndim: int) -> algebra_models.Algebra:
+    """ Instanciate an algebra """
+    return request.param(ndim)  # Instanciate a model
+
+
+@pytest.fixture(params=[1, 4])
+def batch_ndim(request: Any) -> int:
+    """ Number of batch dimensions """
+    return request.param
+
+
+@pytest.fixture(params=[(1, 20)])
+def batch_shape(request: Any, batch_ndim: int) -> Tuple[int, ...]:
+    """ Innput batch shape """
+    return tuple(random_int_list(batch_ndim,
+                                 batch_ndim,
+                                 *request.param)())
+
+
+@pytest.fixture(params=[1, 4])
+def data_point(request: Any, batch_shape: Tuple[int, ...]) -> torch.Tensor:
+    """ Sample data point from feature space """
+    return torch.rand(batch_shape + (request.param,))
+
+
+def sample_elem(algebra: algebra_models.Algebra,
+                batch_shape: Tuple[int, ...]) -> torch.Tensor:
+    """ Sample Algebra element """
+    return torch.rand(batch_shape + (algebra.flatdim,))
+
+
+class TestAlgebra:
+    """ Regroup all tests pertaining to an algebra structure
+
+    """
+
+    @staticmethod
+    def test_unit_shape(
+            algebra: algebra_models.Algebra,
+            data_point: torch.Tensor,
+            batch_shape: torch.Tensor) -> None:
+        """
+        test that unit has the appropriate size, when generated from random
+        feature vector
+        """
+        units = algebra.unit(data_point)
+        expected = batch_shape + (algebra.flatdim,)
+        assert units.shape == expected
+
+    @staticmethod
+    def test_comp_shape(
+            algebra: algebra_models.Algebra,
+            batch_shape: torch.Tensor) -> None:
+        """
+        test that composition has the appropriate size, for two randomly
+        generated batches
+        """
+        first_elem = sample_elem(algebra, batch_shape)
+        last_elem = sample_elem(algebra, batch_shape)
+        composite = algebra.comp(first_elem, last_elem)
+        expected = batch_shape + (algebra.flatdim,)
+        assert composite.shape == expected
+
+    @staticmethod
+    def test_unit_left(
+            algebra: algebra_models.Algebra,
+            data_point: torch.Tensor,
+            batch_shape: torch.Tensor) -> None:
+        """
+        test that multiplication of a random batch by a batch of units
+        on the left does not change the batch value
+        """
+        elems = sample_elem(algebra, batch_shape)
+        unit = algebra.unit(data_point)
+        composite = algebra.comp(unit, elems)
+        assert algebra.equals(composite, elems)
+
+    @staticmethod
+    def test_unit_right(
+            algebra: algebra_models.Algebra,
+            data_point: torch.Tensor,
+            batch_shape: torch.Tensor) -> None:
+        """
+        test that multiplication of a random batch by a batch of units
+        on the left does not change the batch value
+        """
+        elems = sample_elem(algebra, batch_shape)
+        unit = algebra.unit(data_point)
+        composite = algebra.comp(elems, unit)
+        assert algebra.equals(composite, elems)
+
+    @staticmethod
+    def test_associativity(
+            algebra: algebra_models.Algebra) -> None:
+        """
+        test algebra implementations are actually associative
+        """
+        batch_shape = (3, 100)
+        elems = sample_elem(algebra, batch_shape)
+        left = algebra.comp(
+            algebra.comp(elems[0], elems[1]),
+            elems[2])
+        right = algebra.comp(
+            elems[0],
+            algebra.comp(elems[1], elems[2]))
+        assert algebra.equals(left, right)

--- a/tests/test_fulllayermodels.py
+++ b/tests/test_fulllayermodels.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""
+Created on Fri May 11 12:49:40 2018
+
+@author: christophe_c
+
+tests for full layer models
+"""
+
+import random
+from typing import List, Tuple
+import pytest
+import torch
+from torch import nn
+
+from tests.test_tools import random_int_list
+from catlearn.full_layer_models import (
+    ConstantModel,
+    LayeredModel,
+    FullPerceptron,
+    FullPerceptronWithRandomState,
+    couple_layered_models,
+    reduce_model)
+
+TensorShape = Tuple[int, ...]
+
+
+@pytest.fixture(params=[(1, 3, 1, 5)])
+def batch_shape(request) -> TensorShape:
+    """ Input batch shape """
+    return tuple(random_int_list(*request.param)())
+
+
+@pytest.fixture(params=[(1, 3, 8, 16)])
+def input_shape(request) -> TensorShape:
+    """ Shape of a single input """
+    return tuple(random_int_list(*request.param)())
+
+
+@pytest.fixture(params=[(1, 3, 8, 16)])
+def output_shape(request) -> TensorShape:
+    """ Shape of a single output """
+    return tuple(random_int_list(*request.param)())
+
+
+@pytest.fixture(params=[(1, 4, 2, 32)])
+def num_units(request) -> List[int]:
+    """ Number of hidden units per layer """
+    return list(random_int_list(*request.param)())
+
+
+@pytest.fixture(params=[(1, 32)])
+def num_random(request) -> int:
+    """ Random state extension """
+    return random.randint(*request.param)
+
+
+def test_constant_model() -> None:
+    """ Test ConstantModel creation and usage """
+    cons = ConstantModel(lambda x: x**2, "square")
+    assert str(cons) == "square"
+    assert cons.forward(2.0) == 4.0
+    assert list(cons.parameters()) == []
+
+
+class TestLayeredModel:
+    """ Test creation and manipulation of LayereModel
+
+    """
+    @staticmethod
+    def get_layered_model(nlayer):
+        """ Create a leyered model with given number of
+        identical ConstantMoel layers
+        """
+        consts = [ConstantModel(lambda x: 2 * x, "double")
+                  for _ in range(nlayer)]
+        return LayeredModel((1,), (1,), consts)
+
+    def test_creation(self) -> None:
+        """ Test creation of a layered model """
+        nlayer = 4
+        layered = self.get_layered_model(nlayer)
+        assert all(isinstance(c, ConstantModel)
+                   for c in layered.children())
+        assert len(list(layered.children())) == nlayer
+        # Self, Sequential and 4 "double"
+        assert len(list(layered.modules())) == 2 + nlayer
+        assert list(layered.parameters()) == []
+        # pylint: disable=not-callable
+        expected = torch.tensor((2**nlayer,), dtype=torch.float32)
+        assert layered.forward(torch.ones(1)) == expected
+
+    def test_reduce_model(self) -> None:
+        """ Test reduce_model helper """
+        nlayer = 5
+        layered = self.get_layered_model(nlayer)
+        reduced = reduce_model(layered)
+
+        assert len(reduced.layers) == 1
+        assert len(list(layered.children())) == nlayer
+        assert layered.forward(torch.ones(1)) \
+            == reduced.forward(torch.ones(1))
+
+    def test_couple_models(self) -> None:
+        """ Test couple_layered_models helper """
+        l1 = self.get_layered_model(4)
+        l2 = self.get_layered_model(3)
+        l3 = self.get_layered_model(5)
+        coupled = couple_layered_models(l1, l2, l3)
+        expected = self.get_layered_model(4 + 3 + 5)
+
+        assert len(coupled.layers) == len(expected.layers)
+        assert len(list(coupled.children())) \
+            == len(list(expected.children()))
+        assert coupled.forward(torch.ones(1)) \
+            == expected.forward(torch.ones(1))
+
+
+class TestFullPerceptron:
+    """
+    Test facility for the base FullPerceptron class
+    """
+
+    @staticmethod
+    def get_model(
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int]) -> FullPerceptron:
+        """ Construct Torch module """
+        return FullPerceptron(input_shape, output_shape, num_units, nn.Sigmoid)
+
+    def test_output_shape(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            batch_shape: TensorShape) -> None:
+        """
+        draw random input and verify output has the right shape
+        """
+        model = self.get_model(input_shape, output_shape, num_units)
+        input_batch = torch.rand(batch_shape + input_shape)
+        output_batch = model.forward(input_batch)
+
+        expected_shape = batch_shape + output_shape
+        assert output_batch.shape == expected_shape
+
+    def test_params_list(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int]) -> None:
+        """
+        test that the parameters' list has the right size
+        """
+        model = self.get_model(input_shape, output_shape, num_units)
+        parameters = list(model.parameters())
+        # Input reshape, (Linear, Sigmoid), output reshape
+        assert len(parameters) == 1 + 2 * len(num_units) + 1
+
+    def test_children_list(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int]) -> None:
+        """
+        test that the parameters' list has the right size
+        """
+        model = self.get_model(input_shape, output_shape, num_units)
+        children = list(model.children())
+        # Initial and final reshape
+        assert isinstance(children[0], ConstantModel)
+        assert isinstance(children[-1], ConstantModel)
+        # Alternating Linear -> Sigmoid motif
+        for i, child in enumerate(children[1:-1]):
+            if i % 2 == 0:
+                expected_type = nn.Linear
+            else:
+                expected_type = nn.Sigmoid
+            assert isinstance(child, expected_type), \
+                f"Type mismatch on layer {1+i}: {expected_type}"
+
+
+class TestFullPerceptronWithRandomState:
+    """
+    Test facility for perceptron model with random state
+    """
+    RNG_CHECK_ORDER = 4
+
+    @staticmethod
+    def get_model(
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            num_random: int) -> FullPerceptronWithRandomState:
+        """ Construct Torch module """
+        return FullPerceptronWithRandomState(input_shape,
+                                             output_shape,
+                                             num_units,
+                                             num_random,
+                                             nn.Sigmoid)
+
+    def test_draw_state(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            num_random: int,
+            batch_shape: TensorShape) -> None:
+        """
+        unit test random drawing
+        """
+        model = self.get_model(input_shape, output_shape,
+                               num_units, num_random)
+        base = model.draw_state(batch_shape)
+        for i in range(1, self.RNG_CHECK_ORDER):
+            assert (base != model.draw_state(batch_shape)).all(), i
+
+    def test_input_augment(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            num_random: int,
+            batch_shape: TensorShape) -> None:
+        """
+        draw random input, verify that augmented input is random
+        """
+        model = self.get_model(input_shape, output_shape,
+                               num_units, num_random)
+        batch_input = torch.rand(batch_shape + input_shape)
+        base_augmented_input = model.augment_input(batch_input)
+
+        # verify that subsequent draws are different
+        for i in range(1, self.RNG_CHECK_ORDER):
+            new_draw = model.augment_input(batch_input)
+            # verify deterministic part is unchanged
+            assert (base_augmented_input == new_draw).any(), i
+            # verify random part is actually changing
+            assert not (base_augmented_input == new_draw).all(), i
+
+    def test_output_shape(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            num_random: int,
+            batch_shape: TensorShape) -> None:
+        """
+        draw random input and verify output has the right shape
+        """
+        model = self.get_model(input_shape, output_shape,
+                               num_units, num_random)
+        input_batch = torch.rand(batch_shape + input_shape)
+        output_batch = model.forward(input_batch)
+
+        expected_shape = batch_shape + output_shape
+        assert output_batch.shape == expected_shape
+
+    def test_params_list(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            num_random: int) -> None:
+        """
+        check that the parameters' list has the right shape
+        """
+        model = self.get_model(input_shape, output_shape,
+                               num_units, num_random)
+        parameters = list(model.parameters())
+        assert len(parameters) == 2 * (len(num_units) + 1)
+
+    def test_children_list(
+            self,
+            input_shape: TensorShape,
+            output_shape: TensorShape,
+            num_units: List[int],
+            num_random: int) -> None:
+        """
+        test that the parameters' list has the right size
+        """
+        model = self.get_model(input_shape, output_shape,
+                               num_units, num_random)
+        children = list(model.children())
+        # Input augmentation and flattening
+        assert isinstance(children[0], ConstantModel)
+        assert str(children[0]) == "RandomAugment"
+        # FullPerceptron Initial reshape
+        # redundant since augment_input flattens the input
+        assert isinstance(children[1], ConstantModel)
+        # Alternating Linear -> Sigmoid motif
+        for i, child in enumerate(children[2:-1]):
+            if i % 2 == 0:
+                expected_type = nn.Linear
+            else:
+                expected_type = nn.Sigmoid
+            assert isinstance(child, expected_type), \
+                f"Type mismatch on layer {1+i}: {expected_type}"
+        # Final reshape
+        assert isinstance(children[-1], ConstantModel)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# pylint: disable=redefined-outer-name
+"""
+tests for random graph generation
+"""
+
+from typing import (
+    Any, Callable, Hashable, Dict, Iterable, Tuple,
+    Set, FrozenSet, Optional, List, Union)
+from itertools import repeat, combinations
+from collections import Counter
+from copy import copy
+from operator import and_, or_, add, mul, matmul
+from string import ascii_letters, digits
+import random
+
+import pytest
+
+from catlearn.graph_utils import (
+    DirectedGraph, DirectedAcyclicGraph, GraphRandomFactory)
+
+from tests.test_tools import pytest_generate_tests
+
+
+@pytest.fixture(params=[0, 432358, 98765, 326710, 54092])
+def seed(request: Any) -> int:
+    """
+    seed for random operations
+    """
+    return request.param
+
+
+@pytest.fixture(params=[0., 0.15, 0.45])
+def pruning_factor(request: Any) -> float:
+    """
+    pruning factor for random graph pruning operations
+    """
+    return request.param
+
+
+class TestDirectedGraph:
+    """
+    Unit tests for DirectedGraph class
+    """
+
+    # allowed chars for stringification
+    ALLOWED_CHARS = (frozenset(digits) | frozenset(ascii_letters))
+
+    # parameters for tests
+    params: Dict[str, List[Any]] = {
+        "test_init": [
+            dict(initializer_dict={0: [0, "1"], 2.: [()]},
+                 expected_dict={
+                     0: frozenset({0, "1"}),
+                     "1": frozenset(), 2: frozenset({()}),
+                     (): frozenset()}
+                 ),
+            dict(initializer_dict={0: [1], 1: [[]]},
+                 expected_dict=None)
+            ],
+        "test_op": [
+            dict(initializer_dict={0: [1], 1: []},
+                 expected_op=DirectedGraph({0: [], 1: [0]})),
+            dict(initializer_dict={0: [1], 1: [0]},
+                 expected_op=DirectedGraph({0: [1], 1: [0]})),
+            dict(initializer_dict={0: [], 1: []},
+                 expected_op=DirectedGraph({0: [], 1: []}))
+            ],
+        "test_delitem": [
+            dict(graph=DirectedGraph({0: [], 1: [0, 1], 2: [1]}),
+                 node_to_remove=1,
+                 expected_graph=DirectedGraph({0: [], 2: []})
+                 ),
+            dict(graph=DirectedGraph({}),
+                 node_to_remove=1,
+                 expected_graph=DirectedGraph({})
+                 )
+            ],
+        "test_setitem": [
+            dict(graph=DirectedGraph({0: [], 1: [], 2: []}),
+                 node_to_add=0,
+                 children=[1, 2],
+                 expected_graph=DirectedGraph(
+                     {0: [1, 2], 1: [], 2: []})
+                 ),
+            dict(graph=DirectedGraph({1: [], 2: []}),
+                 node_to_add=0,
+                 children=[1, 2],
+                 expected_graph=DirectedGraph(
+                     {0: [1, 2], 1: [], 2: []})
+                 ),
+            dict(graph=DirectedGraph({}),
+                 node_to_add=0,
+                 children=[1, 2],
+                 expected_graph=DirectedGraph(
+                     {0: [1, 2], 1: [], 2: []})
+                 )
+            ],
+        "test_len": [
+            dict(graph=DirectedGraph({}),
+                 expected_length=0),
+            dict(graph=DirectedGraph({0: [], 1: []}),
+                 expected_length=2),
+            dict(graph=DirectedGraph({0: [1], 1: []}),
+                 expected_length=2)
+            ],
+        "test_iter": [
+            dict(graph=DirectedGraph({0: [], 1: [1], 2: []}),
+                 nodes_set={0, 1, 2}),
+            dict(graph=DirectedGraph({}),
+                 nodes_set={})
+            ],
+        "test_under": [
+            dict(graph=DirectedGraph({0: [1, 2], 1: [], 2: []}),
+                 node=0,
+                 nodes_set={1, 2}),
+            dict(
+                graph=DirectedGraph(
+                    {0: [1, 2], 1: [], 2: [3, 1], 3: [4], 4: []}),
+                node=0,
+                nodes_set={1, 2, 3, 4}
+                )
+            ],
+        "test_over": [
+            dict(graph=DirectedGraph({0: [], 1: [0], 2: [0]}),
+                 node=0,
+                 nodes_set={1, 2}),
+            dict(
+                graph=DirectedGraph(
+                    {0: [], 1: [0, 2], 2: [0], 3: [2], 4: [3]}),
+                node=0,
+                nodes_set={1, 2, 3, 4})
+            ],
+        "test_subgraph": [
+            dict(graph=DirectedGraph({0: [], 1: [], 2: []}),
+                 nodes_set={0},
+                 expected_graph=DirectedGraph({0: []})),
+            dict(graph=DirectedGraph({0: [0, 1], 1: [], 2: [0, 1]}),
+                 nodes_set={0, 1},
+                 expected_graph=DirectedGraph({0: [0, 1], 1: []}))
+            ],
+        "test_binary_operator": [
+            dict(binary_op=or_,
+                 first_graph=DirectedGraph({0: [1], 1: []}),
+                 second_graph=DirectedGraph({0: [], 1: [1]}),
+                 expected_graph=DirectedGraph({
+                     (0, 0): [(0, 1)], (0, 1): [],
+                     (1, 0): [], (1, 1): [(1, 1)]})
+                 ),
+            dict(binary_op=and_,
+                 first_graph=DirectedGraph({0: [1], 1: []}),
+                 second_graph=DirectedGraph({0: [], 1: [1]}),
+                 expected_graph=DirectedGraph({
+                     (0, 0): [], (0, 1): [(1, 1)],
+                     (1, 0): [], (1, 1): []})),
+            dict(binary_op=add,
+                 first_graph=DirectedGraph({0: [1], 1: []}),
+                 second_graph=DirectedGraph({0: [], 1: [1]}),
+                 expected_graph=DirectedGraph({
+                     (0, 0): [(0, 1), (1, 0), (1, 1)],
+                     (0, 1): [(1, 0), (1, 1)],
+                     (1, 0): [], (1, 1): [(1, 1)]})
+                 ),
+            dict(binary_op=matmul,
+                 first_graph=DirectedGraph({0: [1], 1: []}),
+                 second_graph=DirectedGraph({0: [], 1: [1]}),
+                 expected_graph=DirectedGraph({
+                     (0, 0): [(1, 0)], (1, 0): [],
+                     (0, 1): [(1, 1), (0, 1)], (1, 1): [(1, 1)]})
+                 ),
+            dict(binary_op=mul,
+                 first_graph=DirectedGraph({0: [1], 1: []}),
+                 second_graph=DirectedGraph({0: [], 1: [1]}),
+                 expected_graph=DirectedGraph({
+                     (0, 0): [(1, 0)],
+                     (1, 0): [],
+                     (0, 1): [(0, 1), (0, 1), (1, 1)],
+                     (1, 1): [(0, 1), (1, 1)]})
+                 )
+            ],
+        "test_prune": [
+            dict(
+                graph=DirectedGraph(
+                    {0: [1], 1: [2, 3], 2: [], 3: [], 4: [0, 1]}),
+                node_to_prune=1,
+                expected_graph=DirectedGraph(
+                    {0: [2, 3], 2: [], 3: [], 4: [0, 2, 3]})
+                )
+            ],
+        "test_integerify": [
+            dict(graph=DirectedGraph({(0, 0): [], "1": []}),
+                 expected_graph=DirectedGraph({0: [], 1: []})),
+            dict(
+                graph=DirectedGraph({0.5: ["a"], "a": [], 2: [0.5, "a"]}),
+                expected_graph=DirectedGraph({0: [2], 2: [], 1: [0, 2]})
+                )
+            ],
+        "test_stringify": [
+            dict(graph=DirectedGraph({(0, 0): [], "1": []}),
+                 expected_graph=DirectedGraph({"0x0": [], "0x1": []})),
+            dict(graph=DirectedGraph({0.5: ["a"], "a": [], 2: [0.5, "a"]}),
+                 expected_graph=DirectedGraph(
+                     {"0x0": ["0x2"], "0x2": [], "0x1": ["0x0", "0x2"]})
+                 )
+            ],
+        "test_rand_prune": [
+            dict(graph=DirectedGraph({
+                0: [1, 2, 3, 4], 2: [3, 4, 6], 6: [5, 9, 11]})),
+            dict(graph=DirectedGraph({0: []})),
+            dict(graph=DirectedGraph({}))
+            ]
+        }
+
+    @staticmethod
+    def test_init(
+            initializer_dict: Dict[Hashable, Iterable[Hashable]],
+            expected_dict: Optional[Dict[Hashable, FrozenSet[Hashable]]]):
+        """
+        check that initialization builds the correct graphs by adding missing
+        nodes as keys.
+        If the expected_dict is None, awaiting failure with a TypeError raised,
+        because the initnializer_dict is invalid (some nodes are not hashable)
+        """
+        if expected_dict is None:
+            with pytest.raises(TypeError):
+                graph: DirectedGraph = DirectedGraph[Hashable](
+                    initializer_dict)
+        else:
+            graph = DirectedGraph[Hashable](initializer_dict)
+            dict_of_graph = {
+                node: frozenset(children)
+                for node, children in graph.items()}
+            assert dict_of_graph == expected_dict
+
+    @staticmethod
+    def test_op(
+            initializer_dict: Dict[Hashable, Iterable[Hashable]],
+            expected_op: DirectedGraph) -> None:
+        """
+        test that the opposite of the graph is correctly computed at init
+        """
+        graph = DirectedGraph[Hashable](initializer_dict)
+        graph_op = graph.op
+        assert graph_op == expected_op
+
+    @staticmethod
+    def test_delitem(
+            graph: DirectedGraph,
+            node_to_remove: Hashable,
+            expected_graph: DirectedGraph):
+        """
+        test that node deletion works as intended
+        """
+        # copy graph
+        graph_copy = copy(graph)
+
+        # remove node from copy
+        if node_to_remove in graph:
+            del graph_copy[node_to_remove]
+
+            # check the new keys of the graph are well defined
+            assert graph_copy == expected_graph
+        else:
+            with pytest.raises(KeyError):
+                # deleting non existing key should raise a key error
+                del graph_copy[node_to_remove]
+
+    @staticmethod
+    def test_setitem(
+            graph: DirectedGraph,
+            node_to_add: Hashable, children: Iterable[Hashable],
+            expected_graph: DirectedGraph) -> None:
+        """
+        test that resetting the list of children of a node works as intended
+        """
+        graph_copy = copy(graph)
+
+        # reset list associated to node
+        graph_copy[node_to_add] = children
+
+        # verify that graph and its oppposite have expected value
+        assert graph_copy == expected_graph
+        assert graph_copy.op == expected_graph.op
+
+    @staticmethod
+    def test_len(graph: DirectedGraph, expected_length: int) -> None:
+        """
+        Check that the length of the graph and its opposite are right
+        """
+        assert len(graph) == expected_length
+        assert len(graph.op) == expected_length
+
+    @staticmethod
+    def test_iter(graph: DirectedGraph, nodes_set: Set) -> None:
+        """
+        Test that itarating over the nodes of the graph goes though all of the
+        necessary nodes, once only
+        """
+        assert Counter(iter(graph)) == Counter(nodes_set)
+
+    @staticmethod
+    def test_under(graph: DirectedGraph, node: Hashable,
+                   nodes_set: Set[Hashable]) -> None:
+        """
+        tests that the under method returns the required set of nodes
+        """
+        assert graph.under(node) == frozenset(nodes_set)
+
+    @staticmethod
+    def test_over(graph: DirectedGraph, node: Hashable,
+                  nodes_set: Set[Hashable]) -> None:
+        """
+        tests that the over method returns the required set of nodes
+        """
+        assert graph.over(node) == frozenset(nodes_set)
+
+    @staticmethod
+    def test_subgraph(graph: DirectedGraph, nodes_set: Set[Hashable],
+                      expected_graph: DirectedGraph):
+        """
+        Test that subgraph extraction gives the right graph
+        """
+        assert graph.subgraph(nodes_set) == expected_graph
+
+    @staticmethod
+    def test_binary_operator(
+            binary_op: Callable[[Any, Any], Any],
+            first_graph: DirectedGraph, second_graph: DirectedGraph,
+            expected_graph: DirectedGraph) -> None:
+        """
+        Verify that the given binary operator applied to first_graph and
+        second_graph yields expected_graph.
+        """
+        result_graph = binary_op(first_graph, second_graph)
+        result_type = type(result_graph)
+        expected_type = type(expected_graph)
+        assert result_type == expected_type
+        assert result_graph == expected_graph
+
+    @staticmethod
+    def test_prune(
+            graph: DirectedGraph,
+            node_to_prune: Hashable,
+            expected_graph: DirectedGraph) -> None:
+        """
+        Verify that pruning the given node from graph yields the required graph
+        """
+        result_graph = graph.prune(node_to_prune)
+        assert result_graph == expected_graph
+
+    @staticmethod
+    def test_integerify(
+            graph: DirectedGraph, expected_graph: DirectedGraph):
+        """
+        Verify that integerification yields a consistent graph.
+        Ideally we would want a test of isomorphism,
+        but it is complicated, so it tests if
+        the integerification yields the correct integers for each node.
+        Hence this is a reggression test.
+        """
+        integerified_graph = graph.integerify()
+        assert integerified_graph == expected_graph
+
+    @staticmethod
+    def test_stringify(
+            graph: DirectedGraph, expected_graph: DirectedGraph):
+        """
+        Verify that stringification yields a consistent graph. Ideally we would
+        want a test of isomorphism, but it is complicated, so it tests if
+        the stringification yields the correct strings for each node.
+        Hence this is a reggression test.
+        """
+        stringified_graph = graph.stringify()
+        assert all(
+            set(node) <= __class__.ALLOWED_CHARS for node in stringified_graph)  # type: ignore
+        assert stringified_graph == expected_graph
+
+    @staticmethod
+    def test_rand_prune(
+            graph: DirectedGraph, pruning_factor: float, seed: int) -> None:
+        """
+        test that random pruning gives the same result with same seeding
+        """
+        # initialize two random generator with same seed
+        first_random_generator = random.Random()
+        first_random_generator.seed(seed)
+
+        second_random_generator = random.Random()
+        second_random_generator.seed(seed)
+
+        # prune graph using the two different random generators
+        first_pruned_graph = graph.rand_prune(
+            pruning_factor, random_generator=first_random_generator)
+        second_pruned_graph = graph.rand_prune(
+            pruning_factor, random_generator=second_random_generator)
+
+        assert first_pruned_graph == second_pruned_graph
+
+
+class TestAcyclicDirectedGraph:
+    """
+    Unit tests for DirectedAcyclicGraph class
+    """
+    params: Dict[str, List[Any]] = {
+        "test_init": [
+            dict(initializer_dict={0: [1], 1: []}, has_loops=False),
+            dict(initializer_dict={0: [0], 1: []}, has_loops=True),
+            dict(
+                initializer_dict={0: [1], 1: [2, 3], 2: [0]}, has_loops=True)
+            ]
+        }
+
+    @staticmethod
+    def test_init(
+            initializer_dict: Dict[Hashable, Iterable[Hashable]],
+            has_loops: bool) -> None:
+        """
+        Test initialization of acyclic directed graph, in particular that
+        pasting an initializer dictionary with a loop leads to an appropriate
+        error.
+        """
+        if has_loops:
+            with pytest.raises(AssertionError):
+                DirectedAcyclicGraph[Hashable](initializer_dict)
+        else:
+            result = DirectedAcyclicGraph[Hashable](initializer_dict)
+            directed_graph_result = DirectedGraph[Hashable](initializer_dict)
+            assert dict(result) == dict(directed_graph_result)
+
+
+@pytest.fixture(params=[1, 3, 5, 7])
+def nb_steps(request: Any) -> int:
+    """
+    number of steps for the random graph generation
+    """
+    return request.param
+
+
+@pytest.fixture(params=[
+    (0.75, 0., 0., 0., 0.), (0., 0.75, 0., 0., 0.), (0., 0., 0.75, 0., 0.),
+    (0., 0., 0., 0.75, 0.), (0., 0., 0., 0., 0.75),
+    (0.15, 0.15, 0.15, 0.15, 0.15)])
+def weights(request: Any) -> Tuple[float, float, float, float, float]:
+    """
+    weights of operations for random graph factory
+    """
+    return request.param
+
+
+class TestGraphRandomFactory:
+    """
+    Unit tests for random graph factory
+    """
+    params: Dict[str, List[Any]] = {
+        "test_result_equality": [
+            dict(nb_graphs=3, initial_graphs=[DirectedAcyclicGraph({})]),
+            dict(
+                nb_graphs=3,
+                initial_graphs=[
+                    DirectedAcyclicGraph({0: [], 1: []}),
+                    DirectedAcyclicGraph({0: [1], 1: []})])
+            ]
+        }
+
+    @staticmethod
+    def test_result_equality(
+            nb_graphs: int, initial_graphs: List[DirectedAcyclicGraph],
+            nb_steps: int, weights: Tuple[float, float, float, float, float],
+            pruning_factor: float, seed: int) -> None:
+        """
+        Tests that results generated from the same seeds with the same
+        parameters, but 2 different factories, are equal
+        """
+        # instantiate 2 random generators and initialize them with the
+        # same seed
+        first_random_generator = random.Random()
+        first_random_generator.seed(seed)
+
+        second_random_generator = random.Random()
+        second_random_generator.seed(seed)
+
+        # instantiate two graph factories with the same parameters, using the
+        # two random generators
+        first_factory = GraphRandomFactory(
+            weights, nb_graphs, pruning_factor, first_random_generator,
+            *initial_graphs)
+        second_factory = GraphRandomFactory(
+            weights, nb_graphs, pruning_factor, second_random_generator,
+            *initial_graphs)
+
+        assert all(
+            repeat(next(first_factory) == next(second_factory), nb_steps))  # type: ignore

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sat May 12 13:10:12 2018
+@author: christophe_c
+a module for useful functions for testing
+"""
+
+from typing import Callable, Iterator
+import random
+
+
+def pytest_generate_tests(metafunc):
+    """
+    called once for each test function. Decorates the test runs with the right
+    parametrization. The parametrization of each function is to be found in a
+    params dictionary in the same scope as the function, in a list associated
+    to the key being the name of the function.
+    """
+
+    # collect parameters list for test
+    func_name = metafunc.function.__name__
+    if hasattr(metafunc.cls, "params") and func_name in metafunc.cls.params:
+        funcarglist = metafunc.cls.params[func_name]
+    else:
+        # if no parameters are declared, do as if the params list is empty
+        funcarglist = []
+
+    # if specific arguments are declared, execute tests using those
+    if funcarglist:
+        argnames = sorted(funcarglist[0])
+        metafunc.parametrize(
+            argnames, [
+                [funcargs[name] for name in argnames]
+                for funcargs in funcarglist]
+            )
+    else:
+        # no specific parameters. Any existing fixture will still be used.
+        print(
+            f"No specific parametrization found"
+            f" for {metafunc.cls.__name__}.{func_name}")
+
+
+def random_int_list(min_length: int,
+                    max_length: int,
+                    min_member: int,
+                    max_member: int) -> Callable[[], Iterator[int]]:
+    """
+    Draws a list of integers of random size
+
+    params:
+    - min_length: the minimum length of the list
+    - max_length: the maximum length of the list
+    - member_min: the minimum value of members of the list
+    - member_max: the maximum value of members of the list
+    """
+    assert min_length >= 0, "a list cannot have negative length"
+    assert max_length >= min_length
+    assert max_member >= min_member
+
+    # draw list length
+    length = random.randint(min_length, max_length)
+
+    # return the generator
+    return lambda: (random.randint(min_member, max_member)
+                    for _ in range(length))


### PR DESCRIPTION
All imports used for the first version of the core, from TheLearningCat.
Some files were renamed (graph_utils.py contains all graph only utils which were in causal_example_generation).