### PR TITLE
Catlearn relation rework

### DIFF
--- a/catlearn/categorical_model.py
+++ b/catlearn/categorical_model.py
@@ -5,6 +5,7 @@ for the categorical model
 
 from __future__ import annotations
 from itertools import chain
+from types import MappingProxyType
 from typing import Any, Callable, IO, Iterable, Mapping, Tuple, Union
 
 import torch
@@ -104,6 +105,13 @@ class DecisionCatModel:
         access the algebra of the decision model
         """
         return self._algebra_model
+
+    @property
+    def label_universe(self) -> Mapping[ArrowType, Tsor]:
+        """
+        access the label encoding
+        """
+        return MappingProxyType(self._label_universe)
 
     def score(
             self, source: Tsor, target: Tsor,

--- a/catlearn/categorical_model.py
+++ b/catlearn/categorical_model.py
@@ -1,23 +1,17 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
-Created on Sat Apr 28 12:12:01 2018
-@author: christophe_c
 This file introduces the factories for creating the necessary cost functions
 for the categorical model
 """
 
 from __future__ import annotations
 from itertools import chain
-from types import MappingProxyType
-from typing import Any, Callable, Dict, IO, Iterable, Mapping, Tuple, Union
+from typing import Any, Callable, IO, Iterable, Mapping, Tuple, Union
 
 import torch
 from torch.optim import Optimizer
 
 from catlearn.tensor_utils import (
-    DEFAULT_EPSILON, Tsor,
-    remap_subproba)
+    DEFAULT_EPSILON, Tsor, remap_subproba)
 from catlearn.graph_utils import DirectedGraph, NodeType
 from catlearn.composition_graph import CompositeArrow, ArrowType
 from catlearn.relation_cache import RelationCache
@@ -42,9 +36,9 @@ class AbstractModel:
 class RelationModel(AbstractModel):
     def __call__(self,
                  src: Tsor,
-                 dst: Tsor) -> Tsor:
+                 dst: Tsor,
+                 rel: ArrowType) -> Tsor:
         raise NotImplementedError()
-
 
 class ScoringModel(AbstractModel):
     def __call__(self,
@@ -52,8 +46,8 @@ class ScoringModel(AbstractModel):
                  dst: Tsor,
                  rel: Tsor) -> Tsor:
         raise NotImplementedError()
-# pylint: enable=missing-docstring
 
+# pylint: enable=missing-docstring
 
 class DecisionCatModel:
     """
@@ -71,8 +65,10 @@ class DecisionCatModel:
     on batch dimensions for everything to work fine
     !!!
     Constructor takes as input:
-        relation_models: a collection of relation models (Sequence[Callable]),
-                taking a couple of 2 datapoints and returning a relation vector
+        relation_model: a model taking 2 datapoints and an encoded relation label,
+                returning a relation vector
+        label_universe: mapping from the set of possible relation label to
+                a suitable form for relation_model
         scoring_model: a single scoring model (Callable), taking a couple of
                 datapoints and a relation between them, and returning
                 confidence scores. Each entry in output tensor should be in
@@ -86,7 +82,8 @@ class DecisionCatModel:
 
     def __init__(
             self,
-            relation_models: Mapping[ArrowType, RelationModel],
+            relation_model: RelationModel,
+            label_universe: Mapping[ArrowType, Tsor],
             scoring_model: ScoringModel,
             algebra_model: Algebra,
             epsilon: float = DEFAULT_EPSILON) -> None:
@@ -95,7 +92,8 @@ class DecisionCatModel:
         """
         assert epsilon > 0., "epsilon should be strictly positive"
 
-        self._relation_models = relation_models
+        self._relation_model = relation_model
+        self._label_universe = label_universe
         self._scoring_model = scoring_model
         self._algebra_model = algebra_model
         self.epsilon = epsilon
@@ -106,13 +104,6 @@ class DecisionCatModel:
         access the algebra of the decision model
         """
         return self._algebra_model
-
-    @property
-    def relations(self) -> Mapping[ArrowType, RelationModel]:
-        """
-        access the mapping to relation models
-        """
-        return MappingProxyType(self._relation_models)
 
     def score(
             self, source: Tsor, target: Tsor,
@@ -138,8 +129,8 @@ class DecisionCatModel:
         generate a batch from a list of relations and datas
         """
         return RelationCache(
-            self.relations, self.score,
-            self.algebra.comp, data_points, relations)
+            self._relation_model, self._label_universe,
+            self.score, self.algebra.comp, data_points, relations)
 
     def cost(
             self,
@@ -192,8 +183,10 @@ class TrainableDecisionCatModel(DecisionCatModel):
     torch modules.
 
     Constructor takes as input:
-        relation_models: a collection of relation models (Sequence[Callable]),
-                taking a couple of 2 datapoints and returning a relation vector
+        relation_model: a model taking 2 datapoints and an encoded relation label,
+                returning a relation vector
+        label_universe: mapping from the set of possible relation label to
+               a suitable form for relation_model
         scoring_model: a single scoring model (Callable), taking a couple of
                 datapoints and a relation between them, and returning
                 confidence scores. Each entry in output tensor should be in
@@ -210,7 +203,8 @@ class TrainableDecisionCatModel(DecisionCatModel):
 
     def __init__(
             self,
-            relation_models: Mapping[ArrowType, RelationModel],
+            relation_model: RelationModel,
+            label_universe: Mapping[ArrowType, Tsor],
             scoring_model: ScoringModel,
             algebra_model: Algebra,
             optimizer: Optimizer,
@@ -220,8 +214,8 @@ class TrainableDecisionCatModel(DecisionCatModel):
         instanciate a new model
         """
         DecisionCatModel.__init__(
-            self, relation_models, scoring_model,
-            algebra_model=algebra_model,
+            self, relation_model, label_universe,
+            scoring_model, algebra_model=algebra_model,
             epsilon=epsilon)
 
         self._cost = torch.zeros(())
@@ -242,8 +236,7 @@ class TrainableDecisionCatModel(DecisionCatModel):
         """
         returns an iterator over parameters of the model
         """
-        return lambda: chain(*(rel.parameters()
-                               for rel in self.relations.values()),
+        return lambda: chain(self._relation_model.parameters(),
                              self._scoring_model.parameters())
 
     def freeze(self) -> None:
@@ -251,16 +244,14 @@ class TrainableDecisionCatModel(DecisionCatModel):
         Freeze all adjustable weights (score and relations)
         """
         self._scoring_model.freeze()
-        for rel in self.relations.values():
-            rel.freeze()
+        self._relation_model.freeze()
 
     def unfreeze(self) -> None:
         """
         Inverse of freeze method
         """
         self._scoring_model.unfreeze()
-        for rel in self.relations.values():
-            rel.unfreeze()
+        self._relation_model.unfreeze()
 
     @property
     def total_cost(self) -> Tsor:

--- a/catlearn/composition_graph.py
+++ b/catlearn/composition_graph.py
@@ -230,7 +230,7 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
             comp: Callable[
                 [
                     CompositionGraph[NodeType, ArrowType, AlgebraType],
-                    CompositeArrow],
+                    CompositeArrow[NodeType, ArrowType]],
                 AlgebraType],
             arrows: Iterable[
                 CompositeArrow[NodeType, ArrowType]] = iter(())) -> None:
@@ -258,7 +258,7 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
         """
         return self._graph
 
-    def add(self, arrow: CompositeArrow) -> None:
+    def add(self, arrow: CompositeArrow[NodeType, ArrowType]) -> None:
         """
         Add the given composite arrow to the composition graph
         """
@@ -330,7 +330,7 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
 
         return iter(())
 
-    def __iter__(self) -> Iterator[CompositeArrow]:
+    def __iter__(self) -> Iterator[CompositeArrow[NodeType, ArrowType]]:
         """
         Return an iterator over all composite arrows of the structure
         """

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -69,6 +69,26 @@ class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: 
         """
         return self.reverse(copy=False)
 
+    def dualize_relations(self) -> DirectedGraph[NodeType]:
+        """
+        returns the dually augmented graph
+
+        No-op if graph has no labels.
+        For each labelled edge (src, dst, label), the resulting
+        graph will have 2 edges:
+            * (src, dst, (label, False)) : the original edge
+            * (src, dst, (label, True)): the dual label
+        Comment: the label value is copied between an edge and its dual
+        """
+        dualg = DirectedGraph()
+        for src, dst in self.edges():
+            dualg.add_edge(src, dst)
+            for label, value in self[src][dst].items():
+                dualg[src][dst][(label, False)] = value
+                dualg[src][dst][(label, True)] = value  # Dual
+        return dualg
+
+
     def under(self, root: NodeType) -> FrozenSet[NodeType]:
         """
         Returns the set of all nodes acessible from given root,

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 from typing import Mapping, Callable, Iterable, Iterator, Generic, Tuple
 from collections import abc
 
@@ -112,7 +113,7 @@ class RelationCache(
 
         # memorize existing arrow model names
         self.relation_embed = rel_embed
-        self.label_universe = label_universe
+        self._label_universe = label_universe
 
         # register scorer and composition operation
         self._scorer = scorer
@@ -153,6 +154,13 @@ class RelationCache(
 
         # if arrow has length 0, return data corresponding to its node
         return self._datas[arrow[0]]  # type: ignore
+
+    @property
+    def label_universe(self) -> Mapping[ArrowType, Tsor]:
+        """
+        access the label encoding
+        """
+        return MappingProxyType(self._label_universe)
 
     def __getitem__(
             self, arrow: CompositeArrow[NodeType, ArrowType]

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -1,11 +1,4 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Sun Mar 24 20:32:59 2019
-
-@author: christophe_c
-"""
-from typing import Mapping, Callable, Iterable, Generic, Tuple, Iterator
+from typing import Mapping, Callable, Iterable, Iterator, Generic, Tuple
 from collections import abc
 
 import torch
@@ -16,7 +9,7 @@ from catlearn.composition_graph import (
     ArrowType, CompositeArrow, CompositionGraph)
 
 # Some convenient type aliases
-GeneratorMapping = Mapping[ArrowType, Callable[[Tsor, Tsor], Tsor]]
+RelationEmbedding = Callable[[Tsor, Tsor, Tsor], Tsor]
 Scorer = Callable[[Tsor, Tsor, Tsor], Tsor]
 BinaryOp = Callable[[Tsor, Tsor], Tsor]
 
@@ -39,7 +32,7 @@ class RelationCache(
         """
         def graph_comp(
                 graph: CompositionGraph[NodeType, ArrowType, Tsor],
-                arrow: CompositeArrow[ArrowType, NodeType]
+                arrow: CompositeArrow[NodeType, ArrowType]
             ) -> Tuple[Tsor, Tsor]:
             """
             compute value associated to given arrow, knowing using values
@@ -47,8 +40,9 @@ class RelationCache(
             """
             # case of length 1
             if len(arrow) == 1:
-                rel_value = self.generators[arrow.arrows[0]](
-                    self._datas[arrow[0]], self._datas[arrow[-1]])  # type: ignore
+                rel_value = self.relation_embed(
+                    self._datas[arrow[0]], self._datas[arrow[-1]],
+                    self.label_universe[arrow.arrows[0]])  # type: ignore
                 rel_score = self._scorer(
                     self._datas[arrow[0]], self._datas[arrow[-1]],  # type: ignore
                     rel_value)
@@ -87,7 +81,8 @@ class RelationCache(
 
     def __init__(
             self,
-            generators: GeneratorMapping,
+            rel_embed: RelationEmbedding,
+            label_universe: Mapping[ArrowType, Tsor],
             scorer: Scorer,
             comp: BinaryOp,
             datas: Mapping[NodeType, Tsor],
@@ -95,10 +90,10 @@ class RelationCache(
             epsilon: float = DEFAULT_EPSILON) -> None:
         """
         Initialize a new cache of relations, from:
-           generators:  mapping whose:
-               - keys are possible arrow names
-               - values are functions taking a pair of source, target data
-                   points as input and returning a relation value
+           rel_embed: a relation embedding function returning a tensor from
+               from 2 points and a tensor-valued label
+           label_universe: mapping from the set of possible relation label to
+               a suitable form for rel_embed
            scorer:  a score function returning a score vector from 2 points
                and 1 relation value,
            comp: a composition operation returning a relation value from
@@ -116,7 +111,8 @@ class RelationCache(
         self._datas = dict(datas)
 
         # memorize existing arrow model names
-        self.generators = generators
+        self.relation_embed = rel_embed
+        self.label_universe = label_universe
 
         # register scorer and composition operation
         self._scorer = scorer
@@ -134,6 +130,7 @@ class RelationCache(
         # fill the cache with provided arrows
         for arrow in arrows:
             self.add(arrow)
+
 
     @property
     def causality_cost(self):
@@ -170,7 +167,7 @@ class RelationCache(
             raise ValueError("Cannot get the score of an arrow of length 0")
         return self._graph[arrow][0]
 
-    def __iter__(self) -> Iterator[CompositeArrow]:
+    def __iter__(self) -> Iterator[CompositeArrow[NodeType, ArrowType]]:
         """
         Iterate through arrows contained in the cache
         """
@@ -236,7 +233,7 @@ class RelationCache(
             if (
                     not self.graph.has_edge(src, tar)
                     or not self.graph[src][tar]):
-                for arr in self.generators:
+                for arr in self.label_universe:
                     self.add(CompositeArrow([src, tar], [arr]))
 
             # get scores of existing arrows from src to tar

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -145,21 +145,22 @@ def arrow(request: Any, label_universe: Mapping[int, Tsor]) -> CompositeArrow[in
 
 def get_labels(
         nodes: Iterable[int],
-        nb_scores: int, nb_labels: int) -> DirectedGraph[int]:
+        nb_scores: int,
+        nb_labels: int) -> DirectedGraph[int]:
     """
     Generate a random label graph
     """
-    labels = DirectedGraph[int]()
+    graph = DirectedGraph[int]()
     sources: List[int] = random.choices(list(nodes), k=nb_labels)
     targets: List[int] = random.choices(list(nodes), k=nb_labels)
+    labels: List[int] = random.choices(list(range(nb_labels)), k=nb_labels**2)
 
     for idx, (src, tar) in enumerate(product(sources, targets)):
-        labels.add_edge(src, tar)
+        graph.add_edge(src, tar)
         scores = torch.softmax(
             torch.rand(1 + nb_scores), dim=-1)[..., :-1]
-        labels[src][tar][idx] = scores
-
-    return labels
+        graph[src][tar][labels[idx]] = scores
+    return graph
 
 
 def get_trainable_model(
@@ -173,7 +174,6 @@ def get_trainable_model(
     return TrainableDecisionCatModel(
         relation, label_universe,
         scoring, algebra, torch.optim.SGD, lr=0.001)
-
 
 class TestRelationCache:
     """

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -209,6 +209,16 @@ class TestDirectedGraph:
                 0: [1, 2, 3, 4], 2: [3, 4, 6], 6: [5, 9, 11]})),
             dict(graph=DirectedGraph({0: []})),
             dict(graph=DirectedGraph({}))
+            ],
+        "test_dualize_relations": [
+            dict(graph=DirectedGraph({0: [1], 1: []}),
+                 expected_graph=DirectedGraph({0: [1], 1: []})),
+            dict(graph=DirectedGraph({0: {1: {"label": 1}}, 1: []}),
+                 expected_graph=DirectedGraph({
+                    0: {1: {
+                        ("label", False): 1,
+			("label", True): 1}},
+                    1: []}))
             ]
         }
 
@@ -396,6 +406,15 @@ class TestDirectedGraph:
             pruning_factor, random_generator=second_random_generator)
 
         assert first_pruned_graph == second_pruned_graph
+
+    @staticmethod
+    def test_dualize_relations(
+            graph: DirectedGraph, expected_graph: DirectedGraph) -> None:
+        """
+        test dual property
+        """
+        result = graph.dualize_relations()
+        assert result == expected_graph
 
 
 class TestAcyclicDirectedGraph:


### PR DESCRIPTION
Took way more time than expected. I kept label_universe as a mapping instead of direct tensor because torch tensors are not hashable, and it was breaking many comparison, set retrieval, etc.
