### PR TITLE
Catlearn 15 match negatives

### DIFF
--- a/catlearn/categorical_model.py
+++ b/catlearn/categorical_model.py
@@ -144,7 +144,8 @@ class DecisionCatModel:
             self,
             data_points: Mapping[NodeType, Tsor],
             relations: Iterable[CompositeArrow[NodeType, ArrowType]],
-            labels: DirectedGraph[NodeType]) -> Tuple[
+            labels: DirectedGraph[NodeType],
+            match_negatives: bool =True) -> Tuple[
                 Tsor,
                 RelationCache[NodeType, ArrowType],
                 DirectedGraph[NodeType]]:
@@ -158,7 +159,7 @@ class DecisionCatModel:
         """
         # generate the relation cache and match against labels
         cache = self.generate_cache(data_points, relations)
-        matched = cache.match(labels)
+        matched = cache.match(labels, match_negatives)
 
         total = sum(
             sum(elem for _, elem in costs.values())
@@ -280,13 +281,15 @@ class TrainableDecisionCatModel(DecisionCatModel):
             data_points: Mapping[NodeType, Tsor],
             relations: Iterable[CompositeArrow[NodeType, ArrowType]],
             labels: DirectedGraph[NodeType],
-            step: bool = True) -> Tuple[
+            step: bool = True,
+            match_negatives: bool = True) -> Tuple[
                 RelationCache[NodeType, ArrowType], DirectedGraph[NodeType]]:
         """
         perform one training step on a batch of tuples
         """
         # backprop on the batch
-        cost, cache, matched = self.cost(data_points, relations, labels)
+        cost, cache, matched = self.cost(
+            data_points, relations, labels, match_negatives)
         self._cost = self._cost + cost
 
         if step:

--- a/catlearn/categorical_model.py
+++ b/catlearn/categorical_model.py
@@ -145,7 +145,7 @@ class DecisionCatModel:
             data_points: Mapping[NodeType, Tsor],
             relations: Iterable[CompositeArrow[NodeType, ArrowType]],
             labels: DirectedGraph[NodeType],
-            match_negatives: bool =True) -> Tuple[
+            match_negatives: bool = True) -> Tuple[
                 Tsor,
                 RelationCache[NodeType, ArrowType],
                 DirectedGraph[NodeType]]:

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -410,7 +410,7 @@ class GraphRandomFactory:
         """
         assert 0. <= pruning_factor <= 1., (
             "pruning factor should be between 0. and 1.")
-        assert len(weights) == len(__class__.OPS), (  # type: ignore
+        assert len(weights) == len(__class__.OPS), (  # type: ignore # pylint: disable=undefined-variable
             "Weights sequence should be of length 5, for"
             " or, and, add, mul, matmul operations respectively")
         assert 0 <= len(initial_graphs) <= nb_graphs, (

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -69,6 +69,12 @@ class NegativeMatch(abc.Hashable):
             isinstance(other_object, __class__)  # type: ignore # pylint: disable=undefined-variable
             and self.value == other_object.value)
 
+    def __repr__(self):
+        """
+        String representation of a negative match
+        """
+        return f"{type(self).__name__}({self.value})"
+
 
 class RelationCache(
         Generic[NodeType, ArrowType],  # pylint: disable=unsubscriptable-object

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -21,14 +21,12 @@ def kl_match(
         against_negative: bool = False) -> Tsor:
     """
     Kullback-Leibler divergence based match. Two modes can be used:
-    if against_negative is True, will return the the log of the ratio of the
-    kl of the score against the label and the kl of the score against
-    the negative_label
-    if against_negative is False, will return the kl of the score
-    for the given label
+    - if against_negative is True, will return KL divergence of score versus
+    given label, minus KL divergence of score versus negative label
+    - if against_negative is False, will return the KL divergence of score
+    versus given label
 
-    Additionally if label is not provided or is None,
-    will match against negative label
+    Additionally if label is not provided, it will default to the negative label
     """
     label_vector = torch.zeros(score.shape) if label is None else label
     kl_div = subproba_kl_div(score, label_vector)

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -313,8 +313,18 @@ class RelationCache(
             if (
                     not self.graph.has_edge(src, tar)
                     or not self.graph[src][tar]):
+
                 for arr in self.label_universe:
-                    self.add(CompositeArrow([src, tar], [arr]))
+                    # add arrow
+                    new_arr = CompositeArrow([src, tar], [arr])
+                    self.add(new_arr)
+
+                    # match new arrow against negative label
+                    new_score = kl_match(self[new_arr])
+                    new_label = new_arr.derive()
+                    result_graph[src][tar][
+                        NegativeMatch(new_label)
+                    ] = new_label, new_score
 
             # get scores of existing arrows from src to tar
             scores = {

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -250,7 +250,7 @@ class RelationCache(
                 score = self[arr]
                 match = subproba_kl_div(score, torch.zeros(score.shape))
                 result_graph[arr[0]][arr[-1]][
-                    arr.derive()
+                    None, arr.derive()
                 ] = arr.derive(), match
 
         for src, tar in labels.edges:
@@ -282,10 +282,10 @@ class RelationCache(
                 best_match = min(candidates, key=candidates.get)
 
                 negative_match = 0
-                if best_match in result_graph[src][tar]:
+                if (None, best_match) in result_graph[src][tar]:
                     # get negative match score and remove it from graph
-                    negative_match = result_graph[src][tar][best_match][1]
-                    del result_graph[src][tar][best_match]
+                    negative_match = result_graph[src][tar][None, best_match][1]
+                    del result_graph[src][tar][None, best_match]
 
                 result_graph[src][tar][name] = (
                     best_match, candidates[best_match] + negative_match)

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -299,11 +299,13 @@ class RelationCache(
             for arr in self.arrows():
                 if not result_graph.has_edge(arr[0], arr[-1]):
                     result_graph.add_edge(arr[0], arr[-1])
-                score = self[arr]
+                new_score = kl_match(
+                    self[arr], label=None, against_negative=False)
+                new_label = arr.derive()
+                
                 result_graph[arr[0]][arr[-1]][
-                    NegativeMatch(arr.derive())
-                ] = arr.derive(), kl_match(
-                    score, label=None, against_negative=False)
+                    NegativeMatch(new_label)
+                ] = new_label, new_score
 
         for src, tar in labels.edges:
             # add edge if necessary
@@ -322,12 +324,13 @@ class RelationCache(
                     self.add(new_arr)
 
                     # match new arrow against negative label
-                    new_score = kl_match(
-                        self[new_arr], label=None, against_negative=False)
-                    new_label = new_arr.derive()
-                    result_graph[src][tar][
-                        NegativeMatch(new_label)
-                    ] = new_label, new_score
+                    if match_negatives:
+                        new_score = kl_match(
+                            self[new_arr], label=None, against_negative=False)
+                        new_label = new_arr.derive()
+                        result_graph[src][tar][
+                            NegativeMatch(new_label)
+                        ] = new_label, new_score
 
             # get scores of existing arrows from src to tar
             scores = {

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -20,9 +20,10 @@ def kl_match(
         score: Tsor, label: Optional[Tsor] = None,
         against_negative: bool = False) -> Tsor:
     """
-    Kullback-liebler divergence based match. Two modes can be used:
-    if against_negative is True, will return the log kl ratio of the score
-    for the given label against match for negative label
+    Kullback-Leibler divergence based match. Two modes can be used:
+    if against_negative is True, will return the the log of the ratio of the
+    kl of the score against the label and the kl of the score against
+    the negative_label
     if against_negative is False, will return the kl of the score
     for the given label
 
@@ -32,7 +33,7 @@ def kl_match(
     label_vector = torch.zeros(score.shape) if label is None else label
     kl_div = subproba_kl_div(score, label_vector)
     if against_negative:
-        return kl_div - kl_match(score)
+        return kl_div - kl_match(score, label=None, against_negative=False)
     return kl_div
 
 
@@ -301,7 +302,8 @@ class RelationCache(
                 score = self[arr]
                 result_graph[arr[0]][arr[-1]][
                     NegativeMatch(arr.derive())
-                ] = arr.derive(), kl_match(score)
+                ] = arr.derive(), kl_match(
+                    score, label=None, against_negative=False)
 
         for src, tar in labels.edges:
             # add edge if necessary
@@ -320,7 +322,8 @@ class RelationCache(
                     self.add(new_arr)
 
                     # match new arrow against negative label
-                    new_score = kl_match(self[new_arr])
+                    new_score = kl_match(
+                        self[new_arr], label=None, against_negative=False)
                     new_label = new_arr.derive()
                     result_graph[src][tar][
                         NegativeMatch(new_label)

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -334,7 +334,6 @@ class TestRelationCache:
                     matches[src][tar][label][0] for label in edge_labels)
                 expected_negatives = set(
                     arr.derive() for arr in cache.arrows(src, tar)) - positives
-                print(expected_negatives)
                 for negative in expected_negatives:
                     expected_label = NegativeMatch(negative)
                     assert expected_label in matches[src][tar]

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -16,6 +16,7 @@ import torch
 from torch import nn
 
 import pytest
+from tests.test_tools import pytest_generate_tests
 
 from catlearn.tensor_utils import subproba_kl_div, Tsor
 from catlearn.graph_utils import DirectedGraph

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # pylint: disable=redefined-outer-name, invalid-name, abstract-method, no-self-use
+# pylint: disable=too-few-public-methods,too-many-locals
 """
 Tests for the categorical_model file.
 """
@@ -23,11 +24,8 @@ from catlearn.relation_cache import RelationCache, NegativeMatch
 from catlearn.categorical_model import (
     RelationModel, ScoringModel,
     DecisionCatModel, TrainableDecisionCatModel)
-from catlearn.relation_cache import RelationCache
 from catlearn.algebra_models import (
     Algebra, VectAlgebra, MatrixAlgebra, AffineAlgebra)
-
-from tests.test_tools import pytest_generate_tests
 
 
 # List of algebras to verify

--- a/tests/test_composition_graph.py
+++ b/tests/test_composition_graph.py
@@ -14,6 +14,8 @@ import pytest
 
 from catlearn.composition_graph import CompositeArrow, CompositionGraph
 
+from tests.test_tools import pytest_generate_tests
+
 
 @pytest.fixture(params=[3, 5, 7])
 def to_add(request: Any) -> CompositeArrow[str, str]:

--- a/tests/test_composition_graph.py
+++ b/tests/test_composition_graph.py
@@ -14,8 +14,6 @@ import pytest
 
 from catlearn.composition_graph import CompositeArrow, CompositionGraph
 
-from tests.test_tools import pytest_generate_tests
-
 
 @pytest.fixture(params=[3, 5, 7])
 def to_add(request: Any) -> CompositeArrow[str, str]:

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -383,7 +383,7 @@ class TestDirectedGraph:
         """
         stringified_graph = graph.stringify()
         assert all(
-            set(node) <= __class__.ALLOWED_CHARS for node in stringified_graph)  # type: ignore
+            set(node) <= __class__.ALLOWED_CHARS for node in stringified_graph)  # type: ignore # pylint: disable=undefined-variable
         assert stringified_graph == expected_graph
 
     @staticmethod

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -16,6 +16,7 @@ from string import ascii_letters, digits
 import random
 
 import pytest
+from tests.test_tools import pytest_generate_tests
 
 from catlearn.graph_utils import (
     DirectedGraph, DirectedAcyclicGraph, GraphRandomFactory)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# pylint: disable=redefined-outer-name, invalid-name, abstract-method, no-self-use
+# pylint: disable=redefined-outer-name, invalid-name, abstract-method,no-self-use,too-few-public-methods
 """
 tests for random graph generation
 """
@@ -19,8 +19,6 @@ import pytest
 
 from catlearn.graph_utils import (
     DirectedGraph, DirectedAcyclicGraph, GraphRandomFactory)
-
-from tests.test_tools import pytest_generate_tests
 
 
 @pytest.fixture(params=[0, 432358, 98765, 326710, 54092])
@@ -215,10 +213,8 @@ class TestDirectedGraph:
                  expected_graph=DirectedGraph({0: [1], 1: []})),
             dict(graph=DirectedGraph({0: {1: {"label": 1}}, 1: []}),
                  expected_graph=DirectedGraph({
-                    0: {1: {
-                        ("label", False): 1,
-			("label", True): 1}},
-                    1: []}))
+                     0: {1: {("label", False): 1, ("label", True): 1}},
+                     1: []}))
             ]
         }
 


### PR DESCRIPTION
Adding option to match orphaned relations of a cache negatively. I kept it as optional as I thought we might need to have the previous version of the match for some evaluations.
A class NegativeMatch is added to wrap labels of negative matches.

The following happens when matching with negatives:
- all arrows are negatively matched first. 
- Then labels of the test graph are tested against relations; the best relation is chosen according to minimization of: kl(relation, label) - kl(relation, negative)
- the relations which have been matched positively have their negative match removed.

This is rebased on your branch, so review after merging it.