### PR TITLE
Catlearn 17 random graph sampling

### DIFF
--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -729,3 +729,38 @@ def random_walk_edge_sample(
             else:
                 sampled_graph[src] = {dst: labels}
     return sampled_graph
+
+
+def n_hop_sample(
+        graph: DiGraph[NodeType],
+        n_hops: int,
+        seeds: Optional[Iterable[ArrowType]] = None,
+        n_seeds: int = 1,
+        rng: Optional[random.Random] = None) -> DiGraph[NodeType]:
+    """
+    N-hop sampling from random or specified locations
+
+    Params:
+    - graph: the input graph
+    - n_hops: number of hops
+    - seeds: to root the walk on specific vertices
+    - n_seeds: to start random walk on specified number of uniformly selected vertices
+    - rng: random number generator to use, default to random.Random
+
+    Returns: a valid subgraph, where all edges existing between sampled vertices are kept
+    """
+    if len(graph) == 0 or n_hops <= 0:
+        return DiGraph()
+    elif seeds is None:
+        if rng is None:
+            rng = random.Random()
+        sampled_vertices = set(rng.choices(list(graph), k=n_seeds))
+    else:
+        sampled_vertices = set(seeds)
+
+    for _ in range(1, n_hops):  # Seed sampling is considered 1st hop
+        visited_vertices = set()
+        for v in sampled_vertices:
+            visited_vertices.update(list(graph[v]))
+        sampled_vertices |= visited_vertices
+    return graph.subgraph(sampled_vertices)

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -135,11 +135,11 @@ class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: 
         Prune a node out of the graph, but making sure that for any subgraph
         i -> pruned_node -> j, there is a i -> j vertex added
         """
-        # get parents and children of node - filter out self-reference
-        parents = [v for v in self.op[node].copy() if v != node]
-        children = [v for v in self[node].copy() if v != node]
+        # get parents and children of node
+        parents = self.op[node]
+        children = self[node]
 
-        # delete node
+        # delete node - will handle self (x->x) and back reference (x->y->x)
         del self[node]
 
         # add children to all parents' children sets

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -498,9 +498,11 @@ class GraphRandomFactory:
             for op_nargs in ops_nargs)
 
         # get operands for each operation, with their right variance
+        # Use reverse with copy instead of op, otherwise we get a 'frozen'
+        # view into the graph and we cannot prune it
         operands = (
             map(
-                lambda graph, var: graph if var else graph.op,
+                lambda graph, var: graph if var else graph.reverse(copy=True),
                 self._random_generator.choices(self.graphs, k=op_nargs),
                 ops_vars)
             for op_nargs, ops_vars in zip(ops_nargs, operands_variance))

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -135,9 +135,9 @@ class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: 
         Prune a node out of the graph, but making sure that for any subgraph
         i -> pruned_node -> j, there is a i -> j vertex added
         """
-        # get parents and children of node
-        parents = self.op[node].copy()
-        children = self[node].copy()
+        # get parents and children of node - filter out self-reference
+        parents = [v for v in self.op[node].copy() if v != node]
+        children = [v for v in self[node].copy() if v != node]
 
         # delete node
         del self[node]
@@ -332,7 +332,7 @@ class DirectedAcyclicGraph(DirectedGraph[NodeType]):
     """
     def __init__(self, *args, **kwargs) -> None:
         """
-            Create an acyclic directed graph from a dictinary.
+            Create an acyclic directed graph from a dictionary.
         """
 
         # init self as directed graph

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -543,16 +543,16 @@ def generate_random_graph(
 
 
 def sample(
-        igraph: DirectedGraph[NodeType],
+        graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
         ranking: Callable[[DirectedGraph[NodeType]], Mapping[NodeType, float]],
         rng: random.Random) -> DirectedGraph[NodeType]:
     """
-    Sample a random subgraph of `igraph` with respect to a probability
+    Sample a random subgraph of `graph` with respect to a probability
     distribution `ranking` over the vertices.
 
     Params:
-    - igraph: Input graph
+    - graph: Input graph
     - sample_vertices_size: number of vertices to sample
         (with replacement so actual number might be lower)
     - ranking: probability distribution over the input graph vertices
@@ -562,76 +562,76 @@ def sample(
     A valid random subgraph
 
     """
-    ranks = list(ranking(igraph).items())
+    ranks = list(ranking(graph).items())
     vertices = [v for v, _ in ranks]
     weights = [w for _, w in ranks]
     sampled_vertices = set(rng.choices(vertices, weights, k=int(sample_vertices_size)))
-    return igraph.subgraph(sampled_vertices)
+    return graph.subgraph(sampled_vertices)
 
 
 def pagerank_sample(
-        igraph: DirectedGraph[NodeType],
+        graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
         rng: random.Random,
         **kwargs) -> DirectedGraph[NodeType]:
     """
-    Sample a random subgraph of `igraph` with respect to vertices PageRank scores.
+    Sample a random subgraph of `graph` with respect to vertices PageRank scores.
 
     Details of other parameters: see `sample`
     Pagerank calculation: see `networkx.pagerank`
     NB: `kwargs are all passed to `networkx.pagerank`
     """
     return sample(
-        igraph, sample_vertices_size, lambda g: pagerank(g, **kwargs), rng)
+        graph, sample_vertices_size, lambda g: pagerank(g, **kwargs), rng)
 
 
 def hubs_sample(
-        igraph: DirectedGraph[NodeType],
+        graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
         rng: random.Random,
         **kwargs) -> DirectedGraph[NodeType]:
     """
-    Sample a random subgraph of `igraph` with respect to vertices HITS hubs scores.
+    Sample a random subgraph of `graph` with respect to vertices HITS hubs scores.
 
     Details of other parameters: see `sample`
     Pagerank calculation: see `networkx.hits`
     NB: `kwargs are all passed to `networkx.hits`
     """
     return sample(
-        igraph, sample_vertices_size, lambda g: hits(g, **kwargs)[0], rng)
+        graph, sample_vertices_size, lambda g: hits(g, **kwargs)[0], rng)
 
 
 def authorities_sample(
-        igraph: DirectedGraph[NodeType],
+        graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
         rng: random.Random,
         **kwargs) -> DirectedGraph[NodeType]:
     """
-    Sample a random subgraph of `igraph` with respect to vertices HITS authorities scores.
+    Sample a random subgraph of `graph` with respect to vertices HITS authorities scores.
 
     Details of other parameters: see `sample`
     Pagerank calculation: see `networkx.hits`
     NB: `kwargs are all passed to `networkx.hits`
     """
     return sample(
-        igraph, sample_vertices_size, lambda g: hits(g, **kwargs)[1], rng)
+        graph, sample_vertices_size, lambda g: hits(g, **kwargs)[1], rng)
 
 
 def uniform_sample(
-        igraph: DirectedGraph[NodeType],
+        graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
         rng: random.Random) -> DirectedGraph[NodeType]:
     """
-    Sample a random subgraph of `igraph` with a uniform probability over vertices
+    Sample a random subgraph of `graph` with a uniform probability over vertices
 
     Details of parameters: see `sample`
     """
-    n = len(igraph)
-    return sample(igraph, sample_vertices_size,
+    n = len(graph)
+    return sample(graph, sample_vertices_size,
                   lambda G: {v: 1.0/n for v in G}, rng)
 
 def random_walk_sample(
-        igraph: DirectedGraph[NodeType],
+        graph: DirectedGraph[NodeType],
         rng: random.Random,
         max_path_len: int,
         seeds: Optional[Iterable[NodeType]] = None,
@@ -641,7 +641,7 @@ def random_walk_sample(
     Random Walk graph subsampling
 
     Params:
-    - igraph: the input graph
+    - graph: the input graph
     - rng: random number generator to use
     - max_path_len: maximum path length
     - seeds: to root the walk on specific vertices
@@ -651,7 +651,7 @@ def random_walk_sample(
     Returns: a valid subgraph
     """
     if seeds is None:
-        sampled_vertices = list(rng.choices(list(igraph), k=n_seeds))
+        sampled_vertices = list(rng.choices(list(graph), k=n_seeds))
         max_iter = max_path_len * n_seeds
     else:
         sampled_vertices = list(seeds)
@@ -662,7 +662,7 @@ def random_walk_sample(
         i += 1
         v = rng.choice(sampled_vertices)
         use_op = use_opposite and rng.randint(0, 1) # Flip a coin
-        connected_vertices = list(igraph.op[v] if use_op else igraph[v])
+        connected_vertices = list(graph.op[v] if use_op else graph[v])
         if connected_vertices:
             sampled_vertices.append(rng.choice(connected_vertices))
-    return igraph.subgraph(sampled_vertices)
+    return graph.subgraph(sampled_vertices)

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -309,16 +309,18 @@ class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: 
             "pruning_factor should be a number between 0. and 1.")
         nb_to_prune = int(np.floor(pruning_factor * len(self)))
 
-        # draw nodes to be pruned
+        # Node sampler
         if random_generator is None:
-            to_prune = random.sample(
-                list(self), k=nb_to_prune)  # type: ignore
+            choice = lambda g: random.choice(g)
         else:
-            to_prune = random_generator.sample(
-                list(self), k=nb_to_prune)  # type: ignore
+            choice = lambda g: random_generator.choice(g)
 
         # prune nodes
-        for node in to_prune:
+        for _ in range(nb_to_prune):
+            if len(self) == 0: # Choice function requires non-empty collections
+                break
+            # Draw node to prune
+            node = choice(list(self)) # type: ignore
             self.prune(node)
 
         return self

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -563,8 +563,7 @@ def sample(
 
     """
     ranks = list(ranking(graph).items())
-    vertices = [v for v, _ in ranks]
-    weights = [w for _, w in ranks]
+    vertices, weights = zip(*ranks)
     sampled_vertices = set(rng.choices(vertices, weights, k=int(sample_vertices_size)))
     return graph.subgraph(sampled_vertices)
 

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -21,7 +21,7 @@
 
 remote="$1"
 url="$2"
-repo="Recat-ML"
+repo="catlearn"
 
 # Verify commit naming convention
 z40=0000000000000000000000000000000000000000

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -93,11 +93,15 @@ pylint_check "catlearn/" 2#000011
 # Run pylint on the tests
 pylint_check "tests/" 2#000011 "no-self-use,duplicate-code"
 
-# Type check on package
-type_check "catlearn/"
 
-# Type check on tests
-type_check "tests/"
+# Github #23 - https://github.com/arreason/CategoryLearning/issues/23
+# Deactivate mypy checks, since we have a handful of outstanding errors/warnings
+#
+# # Type check on package
+# type_check "catlearn/"
+#
+# # Type check on tests
+# type_check "tests/"
 
 # Execute unit tests
 py.test -sv --exitfirst --durations=15 --cov=catlearn/ --no-cov-on-fail

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -594,16 +594,17 @@ class TestSubgraphSampling:
         seed = rng.choice(list(graph))
         sg = random_walk_sample(graph, rng, 12, seeds=[seed])
         assert 1 <= len(sg) <= 12
-        assert len(sg.over(seed)) <= 1 # empty, or self-reference
+        assert frozenset() <= sg.over(seed) <= frozenset(seed) # empty, or self-reference
 
     @staticmethod
     def test_random_walk_multiple_roots(rng, graph):
         """ Sanity check on random walk sampler """
         n_seeds = 3
-        sg = random_walk_sample(graph, rng, 5, n_seeds=n_seeds)
+        sg = random_walk_sample(graph, rng, 5, n_seeds=n_seeds, use_opposite=False)
         assert 1 <= len(sg) <= 5 * n_seeds
         # Assert we have at most n_seeds roots
-        assert 1 <= sum(1 for v in sg if len(sg.over(v)) <= 1) <= n_seeds
+        isRoot = lambda v: frozenset() <= sg.over(v) <= frozenset(v)
+        assert 1 <= sum(1 for v in sg if isRoot(v)) <= n_seeds
 
     @staticmethod
     def test_random_walk_with_dual(rng, graph):

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -194,7 +194,7 @@ class TestDirectedGraph:
                  expected_graph=DirectedGraph({0: [], 1: []})),
             dict(
                 graph=DirectedGraph({0.5: ["a"], "a": [], 2: [0.5, "a"]}),
-                expected_graph=DirectedGraph({0: [2], 2: [], 1: [0, 2]})
+                expected_graph=DirectedGraph({2: [1], 1: [], 0: [2, 1]})
                 )
             ],
         "test_stringify": [
@@ -202,7 +202,7 @@ class TestDirectedGraph:
                  expected_graph=DirectedGraph({"0x0": [], "0x1": []})),
             dict(graph=DirectedGraph({0.5: ["a"], "a": [], 2: [0.5, "a"]}),
                  expected_graph=DirectedGraph(
-                     {"0x0": ["0x2"], "0x2": [], "0x1": ["0x0", "0x2"]})
+                     {"0x2": ["0x1"], "0x1": [], "0x0": ["0x2", "0x1"]})
                  )
             ],
         "test_rand_prune": [

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -512,10 +512,14 @@ class TestGraphRandomFactory:
 
 
 class TestSubgraphSampling:
+    """
+    Subgraph sampling test suite
+    """
 
     @staticmethod
     @pytest.fixture
     def rng():
+        """ Return PRNG to use in the test """
         return random.Random()
 
     @staticmethod

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -22,7 +22,7 @@ from catlearn.graph_utils import (
     DirectedGraph, DirectedAcyclicGraph, GraphRandomFactory,
     sample, pagerank_sample, hubs_sample, authorities_sample,
     uniform_sample, random_walk_vertex_sample,
-    random_walk_edge_sample, generate_random_graph)
+    random_walk_edge_sample, n_hop_sample, generate_random_graph)
 
 
 @pytest.fixture(params=[0, 432358, 98765, 326710, 54092])
@@ -634,3 +634,15 @@ class TestSubgraphSampling:
             graph, rng, n_iter, n_seeds=n_seeds,
             use_opposite=True, use_both_ends=True)
         assert 0 <= len(sg.edges) <= n_iter + n_seeds
+
+    @staticmethod
+    @pytest.fixture(params=[0, 1, 2])
+    def n_hops(request: Any) -> int:
+        """ Number of hops """
+        return request.param
+
+    @staticmethod
+    def test_n_hop_sampler(graph, rng, n_hops, n_seeds):
+        """ Sanity checks on n_hop sampler """
+        sg = n_hop_sample(graph, n_hops, n_seeds=n_seeds, rng=rng)
+        assert all(v in graph for v in sg)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -587,7 +587,7 @@ class TestSubgraphSampling:
         seed = rng.choice(list(g))
         sg = random_walk_sample(g, rng, 12, seeds=[seed])
         assert 1 <= len(sg) <= 12
-        assert len(sg.op[seed]) <= 1 # empty, or self-reference
+        assert len(sg.over(seed)) <= 1 # empty, or self-reference
 
     # Sometimes the RandomFactory fails (erode)
     @pytest.mark.flaky(reruns=3)
@@ -599,7 +599,7 @@ class TestSubgraphSampling:
         sg = random_walk_sample(g, rng, 5, n_seeds=n_seeds)
         assert 1 <= len(sg) <= 5 * n_seeds
         # Assert we have at most 3 roots
-        assert 1 <= sum(1 for v in sg.op if len(v) <= 1) <= n_seeds
+        assert 1 <= sum(1 for v in sg if len(sg.over(v)) <= 1) <= n_seeds
 
     # Sometimes the RandomFactory fails (erode)
     @pytest.mark.flaky(reruns=3)

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -538,9 +538,14 @@ class TestSubgraphSampling:
         """
         return generate_random_graph(nb_steps, rng)
 
-    def test_sample(self, rng, graph):
-        """ Test sample respect a given probability distribution """
-        assert False
+    @staticmethod
+    def test_sample(rng, graph):
+        """ Test sample respect a simple probability distribution: only first k nodes """
+        firsts = frozenset(list(graph)[:5])
+        ranking = lambda g: {v: 1.0 if v in firsts else 0.0 for v in g}
+        sg = sample(graph, len(graph), ranking, rng)
+        selected = frozenset(list(sg))
+        assert selected <= firsts
 
     @staticmethod
     def test_uniform(rng, graph):


### PR DESCRIPTION
Update of pull request https://github.com/arreason/CategoryLearning/pull/21

Outstanding question from Kuraao left:
```
Open question: Is the current function really what we want?
The way I see it there is 2 options:

    the current one, where we keep only the nodes which have been sampled
    the one in which instead we keep the edge which have been used during the walk (dunno if that's even practical using networkx). (obviously we also only keep the visited nodes)
```