### PR TITLE
Catlearn 14 compose and prune

### DIFF
--- a/catlearn/algebra_models.py
+++ b/catlearn/algebra_models.py
@@ -11,7 +11,8 @@ from functools import reduce
 from operator import mul
 import torch
 
-from catlearn.tensor_utils import repeat_tensor, zeros_like, DEFAULT_EPSILON
+from catlearn.tensor_utils import (
+    repeat_tensor, zeros_like, ones_like, DEFAULT_EPSILON)
 
 
 class Algebra:
@@ -122,6 +123,59 @@ class VectAlgebra(Algebra):
         assert data1.shape[-1] == self.dim, "inputs should match dim of model"
 
         return data1 + data2
+
+
+class VectMultAlgebra(Algebra):
+    """
+        A class to encapsulate a finite dimensional (possibly dependant on
+        a vector input)
+        R-vector space algebra:
+            unit is 1-vector
+            composition is elementwise multiplication
+    """
+
+    def __init__(self, dim: int) -> None:
+        """
+        Creates new instance of finite dimensional vector space algebra of a
+        given dimension
+        """
+        assert dim >= 1, "Dimension should be strictly positive"
+
+        self._dim: int = dim
+
+    @property
+    def dim(self) -> int:
+        """
+        returns the actual dimension of an element of the model
+        """
+        return self._dim
+
+    @property
+    def flatdim(self) -> int:
+        """
+        returns the actual dimension of an element of the model, once flattened
+        """
+        return self._dim
+
+    def unit(self, data_tuple: torch.Tensor) -> torch.Tensor:
+        """
+        vector unit. Takes a batch as inputs, returns 0 vectors
+        for each vector in the batch
+        """
+        assert data_tuple.ndimension() >= 1, "input should have ndim >= 1"
+
+        return ones_like(data_tuple, data_tuple.shape[:-1] + (self.dim,))
+
+    def comp(self, data1: torch.Tensor, data2: torch.Tensor) -> torch.Tensor:
+        """
+        vector sum. Takes two batches of same shape as inputs, returns their
+        sum
+        """
+        assert data1.shape == data2.shape, "inputs should have the same shape"
+        assert data1.ndimension() >= 1, "input should have ndim >= 1"
+        assert data1.shape[-1] == self.dim, "inputs should match dim of model"
+
+        return data1 * data2
 
 
 class MatrixAlgebra(Algebra):

--- a/catlearn/composition_graph.py
+++ b/catlearn/composition_graph.py
@@ -11,7 +11,6 @@ Utilities for graphs with composite arrows
 from __future__ import annotations
 from typing import (
     TypeVar, Generic, Optional, Union, Iterable, Tuple, Iterator, Callable)
-from numbers import Number
 from collections import abc
 from itertools import chain
 from math import inf
@@ -305,7 +304,7 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
     def arrows(
             self, src: Optional[NodeType] = None,
             tar: Optional[NodeType] = None,
-            arrow_length_range: Tuple[Number, Number] = (0, inf)
+            arrow_length_range: Tuple[int, Optional[int]] = (0, None),
         ) -> Iterator[CompositeArrow[NodeType, ArrowType]]:
         """
         Get an iterator over all arrows starting at src and ending at tar.
@@ -316,6 +315,9 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
         An arrow length range can also be specified. In this case,
         only arrows with a length in the specified range are returned
         """
+        min_length = arrow_length_range[0]
+        max_length = arrow_length_range[1] if arrow_length_range[1] else inf
+
         if (
                 src is not None and tar is not None
                 and self.graph.has_edge(src, tar)):
@@ -323,8 +325,8 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
             return (
                 arr.suspend(src, tar) for arr in self.graph[src][tar]
                 if (
-                    len(arr) >= arrow_length_range[0]
-                    and len(arr) < arrow_length_range[1]))
+                    len(arr) >= min_length
+                    and len(arr) < max_length))
         if src is not None and tar is None and src in self.graph:
             # iterate over all edges starting at src
             return chain(*(

--- a/catlearn/composition_graph.py
+++ b/catlearn/composition_graph.py
@@ -322,11 +322,12 @@ class CompositionGraph(Generic[NodeType, ArrowType, AlgebraType], abc.Mapping): 
                 src is not None and tar is not None
                 and self.graph.has_edge(src, tar)):
             # iterate over all edges from src to tar
+            # careful to length: the derived arrow has length diminished by 1
             return (
                 arr.suspend(src, tar) for arr in self.graph[src][tar]
                 if (
-                    len(arr) >= min_length
-                    and len(arr) < max_length))
+                    len(arr) >= min_length - 1
+                    and len(arr) < max_length - 1))
         if src is not None and tar is None and src in self.graph:
             # iterate over all edges starting at src
             return chain(*(

--- a/catlearn/composition_graph.py
+++ b/catlearn/composition_graph.py
@@ -103,7 +103,7 @@ class CompositeArrow(Generic[NodeType, ArrowType], abc.Sequence):  # pylint: dis
             if index.step:
                 return self.nodes[index]
 
-            # compute start and stop of nodes slice select nodes
+            # compute start and stop of nodes slice
             length = len(self)
             if index.start is None:
                 start = 0

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -302,7 +302,7 @@ class RelationCache(
                 new_score = kl_match(
                     self[arr], label=None, against_negative=False)
                 new_label = arr.derive()
-                
+
                 result_graph[arr[0]][arr[-1]][
                     NegativeMatch(new_label)
                 ] = new_label, new_score
@@ -361,7 +361,8 @@ class RelationCache(
             CompositeArrow[NodeType, ArrowType]]:
         """
             Remove the relation with the lowest score in the cache.
-            Only remove 1st order arrows. arrows which are removed are those with the lowest score relative to other arrows.
+            Only remove 1st order arrows. arrows which are removed are those
+            with the lowest score relative to other arrows.
 
             Returns the relation if it could be removed, None otherwise
         """
@@ -380,7 +381,8 @@ class RelationCache(
                 if arr is not arrow)
 
             for idx in range(len(arrow)):
-                utility[arrow[idx:(idx + 1)]] += max(scores[arrow] - max(other_scores, default=-inf), 0.)
+                utility[arrow[idx:(idx + 1)]] += max(
+                    scores[arrow] - max(other_scores, default=-inf), 0.)
 
         # identify worst relation
         to_remove = min(utility, key=lambda arr: utility[arr])
@@ -393,8 +395,10 @@ class RelationCache(
     def prune_relations(
         self, nb_to_keep: int) -> List[CompositeArrow[NodeType, ArrowType]]:
         """
-            Remove relations with a low score in the cache, and keep only nb_to_keep relations of each order.
-            Only remove 1st order arrows. arrows which are removed are those with the lowest score relative to other arrows.
+            Remove relations with a low score in the cache, and keep only
+            nb_to_keep relations of each order.
+            Only remove 1st order arrows. arrows which are removed are those
+            with the lowest score relative to other arrows.
 
             Returns the list of pruned relations
         """

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -385,7 +385,7 @@ class RelationCache(
                     # verify that candidate arrow's end is causal
                     if (arr_candidate not in self and self.get(
                             arr_candidate[1:],
-                            default=torch.zeros(1)).sum() > 0):
+                            default=torch.zeros(0)).sum() > 0):
                         self.add(arr_candidate)
                         added_arrows.add(arr_candidate)
 

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -380,9 +380,10 @@ class RelationCache(
                 scores[arr] for arr in self.arrows(src, tar)
                 if arr is not arrow)
 
+            arrow_utility = max(
+                scores[arrow] - max(other_scores, default=-inf), 0.)
             for idx in range(len(arrow)):
-                utility[arrow[idx:(idx + 1)]] += max(
-                    scores[arrow] - max(other_scores, default=-inf), 0.)
+                utility[arrow[idx:(idx + 1)]] += arrow_utility
 
         # identify worst relation
         to_remove = min(utility, key=lambda arr: utility[arr], default=None)
@@ -390,14 +391,14 @@ class RelationCache(
         # remove it from all dicts
         if to_remove and isfinite(utility[to_remove]):
             del self[to_remove]
-            return to_remove
+        return to_remove
 
     def prune_relations(
         self, nb_to_keep: int) -> List[CompositeArrow[NodeType, ArrowType]]:
         """
             Remove relations with a low score in the cache, and keep only
             nb_to_keep relations of each order.
-            Only remove 1st order arrows. arrows which are removed are those
+            Only remove 1st order arrows. Arrows which are removed are those
             with the lowest score relative to other arrows.
 
             Returns the list of pruned relations
@@ -407,7 +408,7 @@ class RelationCache(
             relation = (
                 None if len(self) <= nb_to_keep
                 else self._prune_worst_relation())
-            if relation is not None:
-                pruned.append(relation)
-                continue
-            return pruned
+            if relation is None:
+                break
+            pruned.append(relation)
+        return pruned

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -385,10 +385,10 @@ class RelationCache(
                     scores[arrow] - max(other_scores, default=-inf), 0.)
 
         # identify worst relation
-        to_remove = min(utility, key=lambda arr: utility[arr])
+        to_remove = min(utility, key=lambda arr: utility[arr], default=None)
 
         # remove it from all dicts
-        if isfinite(utility[to_remove]):
+        if to_remove and isfinite(utility[to_remove]):
             del self[to_remove]
             return to_remove
 

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -361,7 +361,7 @@ class RelationCache(
 
     def build_composites(
         self, max_arrow_number,
-    ) -> MappingProxyType[int, Set[CompositeArrow[NodeType, ArrowType]]]:
+    ) -> Mapping[int, Set[CompositeArrow[NodeType, ArrowType]]]:
         """
         Build composites at each order, until max_arrow_number is reached
         """

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -150,6 +150,7 @@ class RelationCache(
             comp: BinaryOp,
             datas: Mapping[NodeType, Tsor],
             arrows: Iterable[CompositeArrow[NodeType, ArrowType]],
+            max_arrow_number: Optional[int] = None,
             epsilon: float = DEFAULT_EPSILON) -> None:
         """
         Initialize a new cache of relations, from:
@@ -161,6 +162,12 @@ class RelationCache(
                and 1 relation value,
            comp: a composition operation returning a relation value from
                2 relation values (supposed associative)
+           datas: a dictionary containing the value of each node
+           arrows: a list of arrows to add to the underlying graph
+           max_arrow_number: if None, does nothing. If strictly positive,
+               the cache will attempt to build further composites of the
+               given arrows, until max_arrow_number of arrows is reached
+           epsilon: precision for numerical computations
         """
         self.epsilon = epsilon
         # base assumption: all arrows node supports should be in
@@ -192,6 +199,10 @@ class RelationCache(
         # fill the cache with provided arrows
         for arrow in arrows:
             self.add(arrow)
+
+        # build composites if max_arrow_number is provided
+        if max_arrow_number and max_arrow_number > 0:
+            self.build_composites(max_arrow_number=max_arrow_number)
 
     def arrows(
             self, src: Optional[NodeType] = None,

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -361,7 +361,7 @@ class RelationCache(
             CompositeArrow[NodeType, ArrowType]]:
         """
             Identify the relation with the lowest score in the cache.
-            Only looks at 1st order arrows. arrows which are removed are those
+            Only looks at 1st order arrows. Arrows which are removed are those
             with the lowest score relative to other arrows.
             If all relations have no alternatives and thus cannot be
             removed, return None.

--- a/catlearn/relation_cache.py
+++ b/catlearn/relation_cache.py
@@ -1,7 +1,8 @@
 from types import MappingProxyType
 from typing import (
     Mapping, Callable, Iterable, Generic, Tuple, Iterator, Hashable, Optional)
-from collections import abc
+from collections import abc, defaultdict
+from math import isfinite
 
 import torch
 
@@ -354,3 +355,54 @@ class RelationCache(
                 result_graph[src][tar].pop(NegativeMatch(best_match), None)
 
         return result_graph
+
+    def _prune_worst_relation(self) -> Optional[
+            CompositeArrow[NodeType, ArrowType]]:
+        """
+            Remove the relation with the lowest score in the cache.
+            Only remove 1st order arrows. arrows which are removed are those with the lowest score relative to other arrows.
+
+            Returns the relation if it could be removed, None otherwise
+        """
+        # create a dictionary of total scores of each arrow
+        scores = {
+            arrow: torch.log(torch.sum(self[arrow]))
+            for arrow in self.arrows()}
+
+        # compute marginal utility of each arrow
+        utility = defaultdict(lambda: 0.)
+        for arrow in self.arrows():
+            src = arrow[0]
+            tar = arrow[-1]
+            other_scores = [
+                scores[arr] for arr in self.arrows(src, tar)
+                if arr is not arrow]
+
+            for idx in range(len(arrow)):
+                utility[arrow[idx:(idx + 1)]] += max(scores[arrow] - max(other_scores))
+
+        # identify worst relation
+        to_remove = min(utility, key=lambda arr: utility[arr])
+
+        # remove it from all dicts
+        if isfinite(to_remove):
+            del self[to_remove]
+            return to_remove
+
+    def prune_relations(
+        self, nb_to_keep: int) -> List[CompositeArrrow[NodeType, ArrowType]]:
+        """
+            Remove relations with a low score in the cache, and keep only nb_to_keep relations of each order.
+            Only remove 1st order arrows. arrows which are removed are those with the lowest score relative to other arrows.
+
+            Returns the list of pruned relations
+        """
+        pruned = []
+        while true:
+            relation = (
+                None if len(self) <= nb_to_keep
+                else self._prune_worst_relation())
+            if relation is not None:
+                pruned.append(relation)
+                continue
+            return pruned

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -383,7 +383,7 @@ class TestRelationCache:
         # prune half of points
         pruned = cache.prune_relations(nb_to_keep)
 
-        assert(all(data not in cache for data in pruned))
+        assert all(data not in cache for data in pruned)
         assert(
             len(cache) <= nb_to_keep
             or all(

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -345,6 +345,31 @@ class TestRelationCache:
                         (matches[src][tar][expected_label][1] - expected_cost)
                         <= TEST_EPSILON)
 
+    @staticmethod
+    def test_prune(
+            nb_features: int,
+            relation: RelationModel,
+            label_universe: Mapping[int, Tsor],
+            scoring: ScoringModel, algebra: Algebra,
+            arrow: CompositeArrow[int, Tsor]) -> None:
+        """
+            Test pruning operation
+        """
+        # create cache with one composite arrow
+        cache = TestRelationCache.get_cache(
+            relation, label_universe,
+            scoring, algebra, nb_features, arrow)
+
+        # prune half of points
+        cache_size = len(cache)
+        pruned = cache.prune_relations(cache_size // 2)
+
+        assert(
+            len(cache) <= cache_size // 2
+            or all(
+                len(list(cache.arrows(relation[0], relation[-1])))
+                for relation in cache.arrows() if len(relation) == 1))
+
 
 class TestDecisionCatModel:
     """ Tests for DecisionCatModel class"""

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -423,8 +423,7 @@ class TestRelationCache:
             i: torch.ones(1) for i in range(nb_labels)}
 
         def scoring(src: Tsor, dst: Tsor, rel: Tsor):
-
-            return rel
+            return rel if dst - src < max_arrow_length else torch.zeros(1)
 
         scores_algebra = VectMultAlgebra(1)
 

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -414,12 +414,13 @@ class TestRelationCache:
         def relation(src: Tsor, dst: Tsor, rel: int) -> Tsor:
             return torch.ones(1)
 
-        singleton_universe = {i: torch.ones(1) for i in range(nb_labels)}
+        singleton_universe = {
+            i: torch.full((1,), 1./max_arrow_length) for i in range(nb_labels)}
 
         def scoring(src: Tsor, dst: Tsor, rel: Tsor):
-            return rel if dst - src <= max_arrow_length else torch.zeros(1)
+            return rel
 
-        scores_algebra = VectMultAlgebra(1)
+        scores_algebra = VectAlgebra(1)
 
         complete_cache = TestRelationCache.get_cache(
             relation, singleton_universe,
@@ -432,13 +433,14 @@ class TestRelationCache:
             scoring, scores_algebra, 1,
             *(arrow[idx:idx + 1] for idx in range(len(arrow))),
         )
+
         cache.build_composites(max_arrow_number=max_arrow_number)
 
         assert (
             frozenset(
                 complete_cache.arrows(
                     include_non_causal=False,
-                    arrow_length_range=(0, max_arrow_length)))
+                    arrow_length_range=(0, max_arrow_length + 1)))
             == frozenset(cache.arrows(include_non_causal=False)))
 
 

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -378,7 +378,7 @@ class TestRelationCache:
         # target number of relations to keep
         nb_to_keep = (
             len(cache) - nb_to_prune if nb_to_prune >= 0
-            else nb_to_prune + 1)
+            else -nb_to_prune + 1)
 
         # prune half of points
         pruned = cache.prune_relations(nb_to_keep)

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -416,7 +416,7 @@ class TestRelationCache:
             Test composite building.
         """
 
-        def relation(src: Tsor, dst: Tsor, rel: int) -> Tsor:
+        def relation(_: Tsor, __: Tsor, ___: int) -> Tsor:
             return torch.ones(1)
 
         singleton_universe = {
@@ -428,7 +428,8 @@ class TestRelationCache:
         scores_algebra = VectMultAlgebra(1)
 
         nb_points = len(arrow) + 1
-        datas = {i: torch.tensor([i]) for i in range(nb_points)}
+        datas = {
+            i: torch.full((1,), i, dtype=torch.float) for i in range(nb_points)}
 
         complete_cache = TestRelationCache.get_cache(
             relation, singleton_universe,

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -26,12 +26,12 @@ from catlearn.categorical_model import (
     RelationModel, ScoringModel,
     DecisionCatModel, TrainableDecisionCatModel)
 from catlearn.algebra_models import (
-    Algebra, VectAlgebra, MatrixAlgebra, AffineAlgebra)
+    Algebra, VectAlgebra, VectMultAlgebra, MatrixAlgebra, AffineAlgebra)
 
 
 # List of algebras to verify
 # Automagic, adding an algebra will get tested right away
-CLASSES_TO_TEST = {VectAlgebra, MatrixAlgebra, AffineAlgebra}
+CLASSES_TO_TEST = {VectAlgebra, VectMultAlgebra, MatrixAlgebra, AffineAlgebra}
 
 
 # path to the data of the generators used for synthetic datasets
@@ -190,6 +190,11 @@ class TestRelationCache:
             dict(nb_to_prune=2),
             dict(nb_to_prune=-1),
             dict(nb_to_prune=-2),
+        ],
+        "test_build_composites": [
+            dict(max_arrow_length=1, max_arrow_number=100),
+            dict(max_arrow_length=2, max_arrow_number=100),
+            dict(max_arrow_length=10, max_arrow_number=100),
         ]
     }
 
@@ -380,14 +385,18 @@ class TestRelationCache:
             len(cache) - nb_to_prune if nb_to_prune >= 0
             else -nb_to_prune + 1)
 
-        # prune half of points
+        initial_content = frozenset(cache)
+
         pruned = cache.prune_relations(nb_to_keep)
 
-        assert all(data not in cache for data in pruned)
+        final_content = frozenset(cache)
+
+        assert initial_content == (final_content ^ pruned)
+
         assert(
             len(cache) <= nb_to_keep
             or all(
-                len(list(cache.arrows(relation[0], relation[-1])))
+                len(list(cache.arrows(relation[0], relation[-1]))) == 1
                 for relation in cache.arrows() if len(relation) == 1))
 
 

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -440,7 +440,7 @@ class TestRelationCache:
         cache = TestRelationCache.get_cache(
             relation, singleton_universe,
             scoring, scores_algebra, 1, datas,
-            *(arrow[idx:idx + 1] for idx in range(nb_points)),
+            *(arrow[idx:idx + 1] for idx in range(nb_points - 1)),
         )
 
         cache.build_composites(max_arrow_number=max_arrow_number)

--- a/tests/test_categorical_model.py
+++ b/tests/test_categorical_model.py
@@ -5,9 +5,9 @@
 """
 Tests for the categorical_model file.
 """
-from typing import Any, Dict, Mapping, Iterable, List, Callable
+from typing import Any, Dict, Mapping, Iterable, List, Callable, Optional
 from functools import reduce
-from itertools import combinations, product
+from itertools import combinations, product, chain
 from tempfile import NamedTemporaryFile
 from math import inf
 import random
@@ -206,19 +206,20 @@ class TestRelationCache:
             scoring: ScoringModel,
             algebra: Algebra,
             data_dim: int,
+            datas: Optional[Mapping[int, Tsor]],
             *arr: CompositeArrow[int, Tsor]) -> RelationCache:
         """
         get a relation cache, initialized with random data and one composite
         arrow if given (otherwise it is empty)
         """
-        if arr:
-            datas = {idx: torch.rand(data_dim) for idx in set().union(*arr)}  # type: ignore
-        else:
-            datas = {}
-            arr = ()
+        missing_points =  {
+            idx for idx in chain(*arr) if idx not in (datas or {})}
+        missing_datas = {
+            idx: torch.rand(data_dim) for idx in missing_points}  # type: ignore
 
         return RelationCache[int, Tsor](
-            relation, label_universe, scoring, algebra.comp, datas, arr)
+            relation, label_universe, scoring, algebra.comp,
+            {**(datas or {}), **missing_datas}, arr)
 
     @staticmethod
     def test_relation(
@@ -232,7 +233,8 @@ class TestRelationCache:
         """
         # create cache with one composite arrow
         cache = TestRelationCache.get_cache(
-            relation, label_universe, scoring, algebra, nb_features, arrow)
+            relation, label_universe, scoring, algebra,
+            nb_features, None, arrow)
 
         # compute expected value of corresponding relation
         expected_result = reduce(
@@ -257,7 +259,8 @@ class TestRelationCache:
         """
         # create cache with one composite arrow
         cache = TestRelationCache.get_cache(
-            relation, label_universe, scoring, algebra, nb_features, arrow)
+            relation, label_universe, scoring, algebra, nb_features, None,
+            arrow)
 
         # collect minimum of all total scores of parts of arrow
         # note that actual score of arrow is also taken in the loop
@@ -296,7 +299,8 @@ class TestRelationCache:
         # create cache with one composite arrow
         cache = TestRelationCache.get_cache(
             relation, label_universe,
-            scoring, algebra, nb_features, arrow)
+            scoring, algebra, nb_features, None,
+            arrow)
 
         # create label graph
         labels = get_labels(arrow, nb_scores, nb_labels)
@@ -379,7 +383,8 @@ class TestRelationCache:
         # create cache with one composite arrow
         cache = TestRelationCache.get_cache(
             relation, label_universe,
-            scoring, algebra, nb_features, arrow)
+            scoring, algebra, nb_features, None,
+            arrow)
 
         # target number of relations to keep
         nb_to_keep = (
@@ -415,23 +420,27 @@ class TestRelationCache:
             return torch.ones(1)
 
         singleton_universe = {
-            i: torch.full((1,), 1./max_arrow_length) for i in range(nb_labels)}
+            i: torch.ones(1) for i in range(nb_labels)}
 
         def scoring(src: Tsor, dst: Tsor, rel: Tsor):
+
             return rel
 
-        scores_algebra = VectAlgebra(1)
+        scores_algebra = VectMultAlgebra(1)
+
+        nb_points = len(arrow) + 1
+        datas = {i: torch.tensor([i]) for i in range(nb_points)}
 
         complete_cache = TestRelationCache.get_cache(
             relation, singleton_universe,
             scoring, scores_algebra, 1,
-            arrow,
+            datas, arrow
         )
 
         cache = TestRelationCache.get_cache(
             relation, singleton_universe,
-            scoring, scores_algebra, 1,
-            *(arrow[idx:idx + 1] for idx in range(len(arrow))),
+            scoring, scores_algebra, 1, datas,
+            *(arrow[idx:idx + 1] for idx in range(nb_points)),
         )
 
         cache.build_composites(max_arrow_number=max_arrow_number)


### PR DESCRIPTION
This adds the method necessary to compute composites during training.
I'll be adding more tests (since turning this on will affect several things including training behaviour), but your feedback on the current state is more than welcome.
And this way Igor can start using it.