### PR TITLE
Catlearn 33 uniform relations sampling

### DIFF
--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -764,7 +764,8 @@ def uniform_vertex_sample(
 def uniform_edge_sample(
         graph: DirectedGraph[NodeType],
         sample_edges_size: int,
-        rng: random.Random) -> DirectedGraph[NodeType]:
+        rng: random.Random,
+        with_labels: bool = False) -> DirectedGraph[NodeType]:
     """
     Sample a random subgraph of `graph` with a uniform probability over edges
 
@@ -772,7 +773,7 @@ def uniform_edge_sample(
     """
     return sample_edges(
         graph, sample_edges_size,
-        lambda G: {e: 1. for e in G}, rng)
+        lambda G: {e: 1. for e in G}, rng, with_labels=with_labels)
 
 
 def random_walk_vertex_sample(

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -6,7 +6,7 @@ A library for graph utilities used in our project.
 """
 # from __future__ import annotations
 from typing import (
-    Iterable, FrozenSet, Sequence, TypeVar, Generic,
+    Iterable, FrozenSet, Sequence, TypeVar, Generic, Union,
     Optional, Callable, Tuple, Iterator, Type, Any, Mapping)
 from itertools import chain, product
 import warnings
@@ -71,7 +71,18 @@ class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: 
                     self[node][child].update(labels)
 
     @property
-    def op(self) -> 'DirectedGraph[NodeType]':
+
+    def labeled_edges(self) -> Iterator[Tuple[NodeType, NodeType, Any]]:
+        """
+        list all edges with labels of the graph.
+        Counts an edge multiple times if it has several labels, once per label
+        """
+        return chain(*(
+            ((src, tar, label, value) for (label, value) in labels.items())
+            for (src, tar, labels) in self.edges(data=True)))
+
+    @property
+    def op(self) -> DirectedGraph[NodeType]:
         """
         returns the opposite graph
         """
@@ -554,7 +565,7 @@ def generate_random_graph(
 def sample_vertices(
         graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
-        ranking: Callable[[DirectedGraph[NodeType]], Mapping[NodeType, float]],
+        ranking: Callable[Iterable[NodeType], Mapping[NodeType, float]],
         rng: random.Random) -> DirectedGraph[NodeType]:
     """
     Sample a random subgraph of `graph` with respect to a probability
@@ -573,7 +584,10 @@ def sample_vertices(
     """
     ranks = list(ranking(graph).items())
     vertices, weights = zip(*ranks)
-    sampled_vertices = set(rng.choices(vertices, weights, k=int(sample_vertices_size)))
+    total_weight = sum(weights)
+    sampled_vertices = set(rng.choices(
+        vertices, [weight/total_weight for weight in weights],
+        k=int(sample_vertices_size)))
     return graph.subgraph(sampled_vertices)
 
 
@@ -581,13 +595,17 @@ def sample_edges(
         graph: DirectedGraph[NodeType],
         sample_edges_size: int,
         ranking: Callable[
-            [DirectedGraph[NodeType]],
+            Union[
+                Iterable[Tuple[NodeType, NodeType]],
+                Iterable[Tuple[NodeType, NodeType, Any]],
+            ],
             Mapping[Tuple[NodeType, NodeType, Any, Any], float]],
-        rng: random.Random) -> DirectedGraph[NodeType]:
+        rng: random.Random,
+        with_labels: bool = False,
+    ) -> DirectedGraph[NodeType]:
     """
     Sample a random subgraph of `graph` with respect to a probability
-    distribution `ranking` over the edges. Only works for graphs
-    with labels.
+    distribution `ranking` over the edges. Keeps all the vertices.
 
     Params:
     - graph: Input graph
@@ -595,26 +613,38 @@ def sample_edges(
         (with replacement so actual number might be lower)
     - ranking: probability distribution over the input graph edges
     - rng: Random generator
+    - if with_labels is False, will sample edges of the graph without
+    taking into account the labels. Otherwise it will treat the graph
+    as a multigraph, and count one edge per label (hence if no labels
+    are given an edge is considered as non existing)
 
     Returns:
     A valid random subgraph
 
     """
-    ranks = list(ranking(
-        chain(*(
-            ((src, tar, label, value) for (label, value) in labels.items())
-            for (src, tar, labels) in graph.edges(data=True)))
-    ))
+    graph_edges = list(graph.labeled_edges if with_labels else graph.edges)
+
+    if not graph_edges:
+        return graph.copy()
+
+    ranks = list(ranking(graph_edges).items())
     edges, weights = zip(*ranks)
-    sampled_edges = set(
-        rng.choices(edges, weights, k=int(sample_edges_size))
-    )
+    total_weight = sum(weights)
+    sampled_edges = set(rng.choices(
+        edges, [weight/total_weight for weight in weights],
+        k=int(sample_edges_size)))
 
-    graph_dict = defaultdict(lambda: defaultdict(lambda: {}))
-    for (src, tar, label, value) in sampled_edges:
-        graph_dict[src][tar][label] = value
+    output_graph = DirectedGraph({v: {} for v in graph})
+    for src, tar, *label in sampled_edges:
+        if not output_graph.has_edge(src, tar):
+            output_graph.add_edge(src, tar)
 
-    return DirectedGraph(graph_dict)
+        # if we're working with labels, the unpacking will yield a tuple
+        # with one element after src and tar
+        if with_labels:
+            output_graph[src][tar][label[0]] = graph[src][tar][label[0]]
+
+    return output_graph
 
 
 def pagerank_sample(
@@ -738,12 +768,11 @@ def uniform_edge_sample(
     """
     Sample a random subgraph of `graph` with a uniform probability over edges
 
-    Details of parameters: see `sample`
+    Details of parameters: see `sample_edges`
     """
-    n = sum(len(labels) for (_, _, labels) in graph.edges(data=True))
     return sample_edges(
         graph, sample_edges_size,
-        lambda G: {e: (1.0/n for v in G)}, rng)
+        lambda G: {e: 1. for e in G}, rng)
 
 
 def random_walk_vertex_sample(

--- a/catlearn/graph_utils.py
+++ b/catlearn/graph_utils.py
@@ -82,7 +82,7 @@ class DirectedGraph(Generic[NodeType], DiGraph, abc.MutableMapping):  # pylint: 
             for (src, tar, labels) in self.edges(data=True)))
 
     @property
-    def op(self) -> DirectedGraph[NodeType]:
+    def op(self) -> 'DirectedGraph[NodeType]':
         """
         returns the opposite graph
         """
@@ -565,7 +565,7 @@ def generate_random_graph(
 def sample_vertices(
         graph: DirectedGraph[NodeType],
         sample_vertices_size: int,
-        ranking: Callable[Iterable[NodeType], Mapping[NodeType, float]],
+        ranking: Callable[[Iterable[NodeType]], Mapping[NodeType, float]],
         rng: random.Random) -> DirectedGraph[NodeType]:
     """
     Sample a random subgraph of `graph` with respect to a probability
@@ -595,10 +595,10 @@ def sample_edges(
         graph: DirectedGraph[NodeType],
         sample_edges_size: int,
         ranking: Callable[
-            Union[
+            [Union[
                 Iterable[Tuple[NodeType, NodeType]],
                 Iterable[Tuple[NodeType, NodeType, Any]],
-            ],
+            ]],
             Mapping[Tuple[NodeType, NodeType, Any, Any], float]],
         rng: random.Random,
         with_labels: bool = False,

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -595,7 +595,8 @@ class TestSubgraphSampling:
         sg = uniform_edge_sample(graph, n_edges, rng)
         se = sg.edges
         assert 0 <= len(se) <= n_edges
-        assert all(e in graph for e in sg)
+        assert all(v in graph for v in sg)
+        assert all(e in graph.edges for e in se)
 
     # Sometimes the algorithm does not converge
     @staticmethod

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -21,9 +21,11 @@ from tests.test_tools import pytest_generate_tests
 
 from catlearn.graph_utils import (
     DirectedGraph, DirectedAcyclicGraph, GraphRandomFactory,
-    sample_vertices, pagerank_sample, hubs_sample, authorities_sample,
-    uniform_vertex_sample, random_walk_vertex_sample,
-    random_walk_edge_sample, n_hop_sample, generate_random_graph)
+    sample_vertices, sample_edges,
+    pagerank_sample, hubs_sample, authorities_sample,
+    uniform_vertex_sample, uniform_edge_sample,
+    random_walk_vertex_sample, random_walk_edge_sample,
+    n_hop_sample, generate_random_graph)
 
 
 @pytest.fixture(params=[0, 432358, 98765, 326710, 54092])
@@ -562,18 +564,37 @@ class TestSubgraphSampling:
     def test_sample_vertices(graph, rng):
         """ Test sample respect a simple probability distribution: only first k nodes """
         firsts = frozenset(list(graph)[:5])
-        ranking = lambda g: {v: 1.0 if v in firsts else 0.0 for v in g}
+        ranking = lambda g: {v: 1. if v in firsts else 0. for v in g}
         sg = sample_vertices(graph, len(graph), ranking, rng)
         selected = frozenset(list(sg))
         assert selected <= firsts
 
     @staticmethod
+    def test_sample_edges(graph, rng):
+        """Test sample of edges with respect to a simple proba dist: only
+        first k nodes"""
+        edges = graph.edges
+        firsts = frozenset(list(edges)[:5])
+        ranking = lambda g: {e: 1. if e in firsts else 0. for e in edges}
+        sg = sample_edges(graph, len(list(edges)), ranking, rng)
+        selected = frozenset(list(sg.edges))
+        assert selected <= firsts
+
+    @staticmethod
     def test_uniform_vertex(graph, rng):
-        """ Sanity checks on uniform sampler """
+        """ Sanity checks on uniform vertex sampler """
         n_vertices = max(1, len(graph) - 4)
         sg = uniform_vertex_sample(graph, n_vertices, rng)
         assert 1 <= len(sg) <= n_vertices
         assert all(v in graph for v in sg)
+
+    @staticmethod
+    def test_uniform_edge(graph, rng):
+        """Sanity checks on uniform edge sampler"""
+        n_edges = max(1, len(list(graph.edges)) - 4)
+        sg = uniform_edge_sample(graph, n_edges, rng)
+        assert 1 <= len(sg) <= n_edges
+        assert all(e in graph for e in sg)
 
     # Sometimes the algorithm does not converge
     @staticmethod

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -21,8 +21,8 @@ from tests.test_tools import pytest_generate_tests
 
 from catlearn.graph_utils import (
     DirectedGraph, DirectedAcyclicGraph, GraphRandomFactory,
-    sample, pagerank_sample, hubs_sample, authorities_sample,
-    uniform_sample, random_walk_vertex_sample,
+    sample_vertices, pagerank_sample, hubs_sample, authorities_sample,
+    uniform_vertex_sample, random_walk_vertex_sample,
     random_walk_edge_sample, n_hop_sample, generate_random_graph)
 
 
@@ -559,19 +559,19 @@ class TestSubgraphSampling:
         return request.param
 
     @staticmethod
-    def test_sample(graph, rng):
+    def test_sample_vertices(graph, rng):
         """ Test sample respect a simple probability distribution: only first k nodes """
         firsts = frozenset(list(graph)[:5])
         ranking = lambda g: {v: 1.0 if v in firsts else 0.0 for v in g}
-        sg = sample(graph, len(graph), ranking, rng)
+        sg = sample_vertices(graph, len(graph), ranking, rng)
         selected = frozenset(list(sg))
         assert selected <= firsts
 
     @staticmethod
-    def test_uniform(graph, rng):
+    def test_uniform_vertex(graph, rng):
         """ Sanity checks on uniform sampler """
         n_vertices = max(1, len(graph) - 4)
-        sg = uniform_sample(graph, n_vertices, rng)
+        sg = uniform_vertex_sample(graph, n_vertices, rng)
         assert 1 <= len(sg) <= n_vertices
         assert all(v in graph for v in sg)
 

--- a/tests/test_graph_utils.py
+++ b/tests/test_graph_utils.py
@@ -591,9 +591,10 @@ class TestSubgraphSampling:
     @staticmethod
     def test_uniform_edge(graph, rng):
         """Sanity checks on uniform edge sampler"""
-        n_edges = max(1, len(list(graph.edges)) - 4)
+        n_edges = max(0, len(list(graph.edges)) - 4)
         sg = uniform_edge_sample(graph, n_edges, rng)
-        assert 1 <= len(sg) <= n_edges
+        se = sg.edges
+        assert 0 <= len(se) <= n_edges
         assert all(e in graph for e in sg)
 
     # Sometimes the algorithm does not converge


### PR DESCRIPTION
Adding a generic subgraph sampler for edges, as well as the associated uniform sampler.

It should work for both labeled and unlabeled graphs, but there are only tests for the unlabeled case for now (since for now the graph random generators won't generate labels).

So to do:
- add utilities to generate random labeled graphs to the current random factory
- add the necessary tests for labeled graphs